### PR TITLE
feat: add /ready skill for actionable task extraction

### DIFF
--- a/.claude/claude.md
+++ b/.claude/claude.md
@@ -11,6 +11,7 @@ MIT-licensed data grid with Excel-grade editing. No Pro tier, ever.
 
 | Command      | Description                                                      |
 | ------------ | ---------------------------------------------------------------- |
+| `/ready`     | Find tasks ready to work on (not blocked by parent issues)       |
 | `/project`   | Project board status, create/update issues, milestone management |
 | `/rfc`       | Review RFC design docs, resolve open questions                   |
 | `/sprint`    | Sprint planning, standup, burndown                               |

--- a/.claude/commands/ready.md
+++ b/.claude/commands/ready.md
@@ -1,0 +1,87 @@
+# Gridsmith Ready Tasks
+
+Analyze the GitHub project board and sub-issue hierarchy to find tasks that are **ready to work on right now** — not blocked by incomplete parent issues.
+
+## Context
+
+- **Repo**: retemper/gridsmith
+- **Project Board**: `gh project` with `--owner retemper`, project number `1`
+- **Sub-issue hierarchy**: Parent issues must be completed (or have no blockers) before children can start. Use the GitHub sub-issues API to traverse the tree.
+
+## Execution Flow
+
+### 1. Fetch all open issues with metadata
+
+```bash
+gh issue list --repo retemper/gridsmith --state open --json number,title,labels,milestone --limit 50
+```
+
+### 2. Build the sub-issue tree
+
+For every open issue, check if it is a sub-issue (has a parent) and if it has sub-issues (is a parent):
+
+```bash
+# Check if issue has a parent
+gh api /repos/retemper/gridsmith/issues/<number> --jq '.parent // empty'
+
+# Check if issue has sub-issues
+gh api /repos/retemper/gridsmith/issues/<number>/sub_issues --jq '.[].number'
+```
+
+Build a dependency map:
+- `parent[child] = parentNumber`
+- `children[parent] = [childNumbers...]`
+
+### 3. Determine which issues are "ready"
+
+An issue is **ready** if ALL of the following are true:
+
+1. It is **open**
+2. It has **no open parent issue** — either it has no parent, or its parent is already closed
+3. It is a **leaf node** OR its own scope is workable independent of children (parent issues that define foundational work are ready even if they have open children)
+4. It is not an RFC issue (label `rfc`) — RFCs are design docs, not implementation tasks
+
+An issue is **blocked** if:
+- Its parent issue is still open (the parent's work must be done first)
+
+### 4. Prioritize the ready list
+
+Sort ready issues by:
+1. Priority label: P0-critical > P1-high > P2-medium > P3-low
+2. Milestone order: M0 > M1 > M2 > M3
+3. Issue number (lower = earlier)
+
+### 5. Present results
+
+Show a summary table with milestone filter if `$ARGUMENTS` specifies one (e.g., `M1`, `M2`).
+
+## Response Format
+
+### Ready Tasks
+
+| # | Title | Priority | Milestone | Labels |
+|---|-------|----------|-----------|--------|
+
+### Blocked Tasks
+
+| # | Title | Blocked by | Reason |
+|---|-------|------------|--------|
+
+### Summary
+
+- Total open: X
+- Ready now: Y
+- Blocked: Z
+- Progress: `[████░░░░░░] 40%` (closed / total per milestone)
+
+## Notes
+
+- If `$ARGUMENTS` contains a milestone name (e.g., `M1`), filter to that milestone only
+- If `$ARGUMENTS` contains `--all`, show all milestones
+- Default (no args): show the earliest active milestone (first one with open issues)
+- Always include issue URLs for easy navigation
+- Flag issues that have been open for a long time without progress
+
+## Arguments
+
+$ARGUMENTS


### PR DESCRIPTION
## Summary

- Add `/ready` command that analyzes GitHub project board + sub-issue hierarchy to find tasks ready to work on
- Filters out blocked tasks (parent issue still open) and RFC design docs
- Sorts by priority (P0 > P1 > P2 > P3) and milestone order
- Register the new command in CLAUDE.md

## How it works

1. Fetches all open issues with metadata
2. Traverses sub-issue tree via GitHub API (`/issues/{n}/sub_issues`)
3. Classifies each issue as **ready** or **blocked**
4. Presents a prioritized table with progress summary

## Usage

- `/ready` — show ready tasks for earliest active milestone
- `/ready M1` — filter to M1 milestone
- `/ready --all` — show all milestones

## Test plan

- [ ] Run `/ready` and verify it shows #2 as ready (no parent)
- [ ] Verify #4 shows as blocked (parent #3 is open)
- [ ] Verify `/ready M1` filters correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)