### PR TITLE
feat(core): implement headless core with createGrid API

### DIFF
--- a/.changeset/headless-core.md
+++ b/.changeset/headless-core.md
@@ -1,0 +1,5 @@
+---
+'@gridsmith/core': minor
+---
+
+Add headless core: createGrid() API with reactive state management, plugin system, event bus, sort/filter index mapping

--- a/.claude/commands/ready.md
+++ b/.claude/commands/ready.md
@@ -29,6 +29,7 @@ gh api /repos/retemper/gridsmith/issues/<number>/sub_issues --jq '.[].number'
 ```
 
 Build a dependency map:
+
 - `parent[child] = parentNumber`
 - `children[parent] = [childNumbers...]`
 
@@ -42,11 +43,13 @@ An issue is **ready** if ALL of the following are true:
 4. It is not an RFC issue (label `rfc`) — RFCs are design docs, not implementation tasks
 
 An issue is **blocked** if:
+
 - Its parent issue is still open (the parent's work must be done first)
 
 ### 4. Prioritize the ready list
 
 Sort ready issues by:
+
 1. Priority label: P0-critical > P1-high > P2-medium > P3-low
 2. Milestone order: M0 > M1 > M2 > M3
 3. Issue number (lower = earlier)
@@ -59,13 +62,13 @@ Show a summary table with milestone filter if `$ARGUMENTS` specifies one (e.g., 
 
 ### Ready Tasks
 
-| # | Title | Priority | Milestone | Labels |
-|---|-------|----------|-----------|--------|
+| #   | Title | Priority | Milestone | Labels |
+| --- | ----- | -------- | --------- | ------ |
 
 ### Blocked Tasks
 
-| # | Title | Blocked by | Reason |
-|---|-------|------------|--------|
+| #   | Title | Blocked by | Reason |
+| --- | ----- | ---------- | ------ |
 
 ### Summary
 

--- a/packages/core/src/events.spec.ts
+++ b/packages/core/src/events.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createEventBus } from './events';
+
+interface TestEvents {
+  ping: { message: string };
+  count: { n: number };
+}
+
+describe('EventBus', () => {
+  it('emits and receives events', () => {
+    const bus = createEventBus<TestEvents>();
+    const fn = vi.fn();
+    bus.on('ping', fn);
+
+    bus.emit('ping', { message: 'hello' });
+    expect(fn).toHaveBeenCalledWith({ message: 'hello' });
+  });
+
+  it('supports multiple handlers for the same event', () => {
+    const bus = createEventBus<TestEvents>();
+    const fn1 = vi.fn();
+    const fn2 = vi.fn();
+    bus.on('ping', fn1);
+    bus.on('ping', fn2);
+
+    bus.emit('ping', { message: 'test' });
+    expect(fn1).toHaveBeenCalledTimes(1);
+    expect(fn2).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribes handlers', () => {
+    const bus = createEventBus<TestEvents>();
+    const fn = vi.fn();
+    const unsub = bus.on('ping', fn);
+
+    bus.emit('ping', { message: 'a' });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    unsub();
+    bus.emit('ping', { message: 'b' });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('once() fires handler only once', () => {
+    const bus = createEventBus<TestEvents>();
+    const fn = vi.fn();
+    bus.once('ping', fn);
+
+    bus.emit('ping', { message: 'first' });
+    bus.emit('ping', { message: 'second' });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith({ message: 'first' });
+  });
+
+  it('does not fire handlers for different events', () => {
+    const bus = createEventBus<TestEvents>();
+    const fn = vi.fn();
+    bus.on('ping', fn);
+
+    bus.emit('count', { n: 1 });
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('removeAllListeners clears everything', () => {
+    const bus = createEventBus<TestEvents>();
+    const fn1 = vi.fn();
+    const fn2 = vi.fn();
+    bus.on('ping', fn1);
+    bus.on('count', fn2);
+
+    bus.removeAllListeners();
+
+    bus.emit('ping', { message: 'test' });
+    bus.emit('count', { n: 1 });
+    expect(fn1).not.toHaveBeenCalled();
+    expect(fn2).not.toHaveBeenCalled();
+  });
+
+  it('emitting with no handlers does not throw', () => {
+    const bus = createEventBus<TestEvents>();
+    expect(() => bus.emit('ping', { message: 'test' })).not.toThrow();
+  });
+});

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -1,0 +1,58 @@
+import type { Unsubscribe } from './signal';
+
+export type EventHandler<T = unknown> = (payload: T) => void;
+
+export interface EventBus<TEvents extends object = Record<string, unknown>> {
+  on<K extends keyof TEvents & string>(event: K, handler: EventHandler<TEvents[K]>): Unsubscribe;
+  once<K extends keyof TEvents & string>(event: K, handler: EventHandler<TEvents[K]>): Unsubscribe;
+  emit<K extends keyof TEvents & string>(event: K, payload: TEvents[K]): void;
+  removeAllListeners(): void;
+}
+
+export function createEventBus<
+  TEvents extends object = Record<string, unknown>,
+>(): EventBus<TEvents> {
+  const handlers = new Map<string, Set<EventHandler>>();
+
+  const getHandlers = (event: string): Set<EventHandler> => {
+    let set = handlers.get(event);
+    if (!set) {
+      set = new Set();
+      handlers.set(event, set);
+    }
+    return set;
+  };
+
+  return {
+    on<K extends keyof TEvents & string>(event: K, handler: EventHandler<TEvents[K]>): Unsubscribe {
+      const set = getHandlers(event);
+      set.add(handler as EventHandler);
+      return () => {
+        set.delete(handler as EventHandler);
+      };
+    },
+
+    once<K extends keyof TEvents & string>(
+      event: K,
+      handler: EventHandler<TEvents[K]>,
+    ): Unsubscribe {
+      const unsub = this.on(event, ((payload: TEvents[K]) => {
+        unsub();
+        handler(payload);
+      }) as EventHandler<TEvents[K]>);
+      return unsub;
+    },
+
+    emit<K extends keyof TEvents & string>(event: K, payload: TEvents[K]): void {
+      const set = handlers.get(event);
+      if (!set) return;
+      for (const handler of set) {
+        handler(payload);
+      }
+    },
+
+    removeAllListeners(): void {
+      handlers.clear();
+    },
+  };
+}

--- a/packages/core/src/grid.spec.ts
+++ b/packages/core/src/grid.spec.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createGrid } from './grid';
+import type { Row, ColumnDef, GridPlugin } from './types';
+
+const sampleColumns: ColumnDef[] = [
+  { id: 'name', header: 'Name', type: 'text' },
+  { id: 'age', header: 'Age', type: 'number' },
+  { id: 'city', header: 'City', type: 'text' },
+];
+
+const sampleData: Row[] = [
+  { name: 'Alice', age: 30, city: 'Seoul' },
+  { name: 'Bob', age: 25, city: 'Tokyo' },
+  { name: 'Charlie', age: 35, city: 'Seoul' },
+];
+
+describe('createGrid', () => {
+  it('initializes with data and columns', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+
+    expect(grid.data).toHaveLength(3);
+    expect(grid.columns.get()).toHaveLength(3);
+    expect(grid.rowCount).toBe(3);
+  });
+
+  it('shallow copies initial data (does not mutate original)', () => {
+    const original = [...sampleData];
+    const grid = createGrid({ data: original, columns: sampleColumns });
+
+    grid.setCell(0, 'name', 'Modified');
+    expect(original[0]!.name).toBe('Alice'); // original unchanged
+  });
+
+  it('emits ready event on creation', () => {
+    const fn = vi.fn();
+    const plugin: GridPlugin = {
+      name: 'ready-listener',
+      init(ctx) {
+        ctx.events.on('ready', fn);
+      },
+    };
+
+    createGrid({ data: [], columns: [], plugins: [plugin] });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('cell operations', () => {
+  it('getCell reads by view index', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    expect(grid.getCell(0, 'name')).toBe('Alice');
+    expect(grid.getCell(1, 'age')).toBe(25);
+  });
+
+  it('setCell updates in place and emits event', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    const fn = vi.fn();
+    grid.events.on('data:change', fn);
+
+    grid.setCell(0, 'name', 'Alicia');
+    expect(grid.getCell(0, 'name')).toBe('Alicia');
+    expect(fn).toHaveBeenCalledWith({
+      changes: [{ row: 0, col: 'name', oldValue: 'Alice', newValue: 'Alicia' }],
+    });
+  });
+
+  it('setCell does not emit when value is the same', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    const fn = vi.fn();
+    grid.events.on('data:change', fn);
+
+    grid.setCell(0, 'name', 'Alice');
+    expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+describe('data and column updates', () => {
+  it('setData replaces data and emits event', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    const fn = vi.fn();
+    grid.events.on('data:rowsUpdate', fn);
+
+    const newData = [{ name: 'Dave', age: 40, city: 'Busan' }];
+    grid.setData(newData);
+
+    expect(grid.data).toHaveLength(1);
+    expect(grid.getCell(0, 'name')).toBe('Dave');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('setColumns replaces columns and emits event', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    const fn = vi.fn();
+    grid.events.on('columns:update', fn);
+
+    const newCols: ColumnDef[] = [{ id: 'name', header: 'Full Name' }];
+    grid.setColumns(newCols);
+
+    expect(grid.columns.get()).toHaveLength(1);
+    expect(grid.columns.get()[0]!.header).toBe('Full Name');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('sort', () => {
+  it('sorts data by column ascending', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    grid.sortState.set([{ columnId: 'age', direction: 'asc' }]);
+
+    expect(grid.getCell(0, 'name')).toBe('Bob'); // age 25
+    expect(grid.getCell(1, 'name')).toBe('Alice'); // age 30
+    expect(grid.getCell(2, 'name')).toBe('Charlie'); // age 35
+  });
+
+  it('sorts data descending', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    grid.sortState.set([{ columnId: 'age', direction: 'desc' }]);
+
+    expect(grid.getCell(0, 'name')).toBe('Charlie'); // age 35
+    expect(grid.getCell(2, 'name')).toBe('Bob'); // age 25
+  });
+
+  it('supports multi-column sort', () => {
+    const data: Row[] = [
+      { name: 'Alice', age: 30, city: 'Seoul' },
+      { name: 'Bob', age: 30, city: 'Tokyo' },
+      { name: 'Charlie', age: 25, city: 'Seoul' },
+    ];
+    const grid = createGrid({ data, columns: sampleColumns });
+    grid.sortState.set([
+      { columnId: 'age', direction: 'asc' },
+      { columnId: 'name', direction: 'asc' },
+    ]);
+
+    expect(grid.getCell(0, 'name')).toBe('Charlie'); // age 25
+    expect(grid.getCell(1, 'name')).toBe('Alice'); // age 30, A < B
+    expect(grid.getCell(2, 'name')).toBe('Bob'); // age 30, B
+  });
+});
+
+describe('filter', () => {
+  it('filters by equality', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    grid.filterState.set([{ columnId: 'city', operator: 'eq', value: 'Seoul' }]);
+
+    expect(grid.rowCount).toBe(2);
+    expect(grid.getCell(0, 'name')).toBe('Alice');
+    expect(grid.getCell(1, 'name')).toBe('Charlie');
+  });
+
+  it('filters by contains', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    grid.filterState.set([{ columnId: 'name', operator: 'contains', value: 'li' }]);
+
+    expect(grid.rowCount).toBe(2); // Alice, Charlie
+  });
+
+  it('filters by numeric comparison', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    grid.filterState.set([{ columnId: 'age', operator: 'gte', value: 30 }]);
+
+    expect(grid.rowCount).toBe(2); // Alice (30), Charlie (35)
+  });
+
+  it('combines sort and filter', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    grid.filterState.set([{ columnId: 'city', operator: 'eq', value: 'Seoul' }]);
+    grid.sortState.set([{ columnId: 'age', direction: 'desc' }]);
+
+    expect(grid.rowCount).toBe(2);
+    expect(grid.getCell(0, 'name')).toBe('Charlie'); // age 35
+    expect(grid.getCell(1, 'name')).toBe('Alice'); // age 30
+  });
+});
+
+describe('indexMap', () => {
+  it('maps view to data indices', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    grid.sortState.set([{ columnId: 'age', direction: 'asc' }]);
+
+    const map = grid.indexMap.get();
+    // Bob (age 25) is at data index 1, view index 0
+    expect(map.viewToData(0)).toBe(1);
+    expect(map.dataToView(1)).toBe(0);
+  });
+
+  it('dataToView returns null for filtered-out rows', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    grid.filterState.set([{ columnId: 'city', operator: 'eq', value: 'Seoul' }]);
+
+    const map = grid.indexMap.get();
+    expect(map.dataToView(1)).toBeNull(); // Bob is in Tokyo, filtered out
+  });
+
+  it('throws on out-of-range viewToData', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    expect(() => grid.indexMap.get().viewToData(999)).toThrow(RangeError);
+    expect(() => grid.indexMap.get().viewToData(-1)).toThrow(RangeError);
+  });
+});
+
+describe('batchUpdate', () => {
+  it('batches multiple changes into one notification cycle', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    const changeFn = vi.fn();
+    grid.events.on('data:change', changeFn);
+
+    grid.batchUpdate(() => {
+      grid.setCell(0, 'name', 'X');
+      grid.setCell(1, 'name', 'Y');
+    });
+
+    // Each setCell emits independently, but signal notifications are batched
+    expect(changeFn).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('subscribe helper', () => {
+  it('subscribes and unsubscribes to events', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    const fn = vi.fn();
+    const unsub = grid.subscribe('data:change', fn);
+
+    grid.setCell(0, 'name', 'Test');
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    unsub();
+    grid.setCell(0, 'name', 'Test2');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('destroy', () => {
+  it('emits destroy event and cleans up', () => {
+    const cleanupFn = vi.fn();
+    const plugin: GridPlugin = {
+      name: 'cleanup-test',
+      init: () => cleanupFn,
+    };
+    const grid = createGrid({ data: sampleData, columns: sampleColumns, plugins: [plugin] });
+
+    const destroyFn = vi.fn();
+    grid.events.on('destroy', destroyFn);
+
+    grid.destroy();
+    expect(destroyFn).toHaveBeenCalledTimes(1);
+    expect(cleanupFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('is idempotent', () => {
+    const grid = createGrid({ data: [], columns: [] });
+    grid.destroy();
+    grid.destroy(); // should not throw
+  });
+
+  it('throws on getCell after destroy', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    grid.destroy();
+    expect(() => grid.getCell(0, 'name')).toThrow(/destroyed/);
+  });
+
+  it('throws on setCell after destroy', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    grid.destroy();
+    expect(() => grid.setCell(0, 'name', 'X')).toThrow(/destroyed/);
+  });
+
+  it('throws on setData after destroy', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    grid.destroy();
+    expect(() => grid.setData([])).toThrow(/destroyed/);
+  });
+
+  it('throws on setColumns after destroy', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    grid.destroy();
+    expect(() => grid.setColumns([])).toThrow(/destroyed/);
+  });
+});
+
+describe('reactive state', () => {
+  it('indexMap recomputes on sort change', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    const fn = vi.fn();
+    grid.indexMap.subscribe(fn);
+
+    grid.sortState.set([{ columnId: 'age', direction: 'asc' }]);
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it('indexMap recomputes on filter change', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    const fn = vi.fn();
+    grid.indexMap.subscribe(fn);
+
+    grid.filterState.set([{ columnId: 'city', operator: 'eq', value: 'Seoul' }]);
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it('emits sort:change event when sortState changes', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    const fn = vi.fn();
+    grid.events.on('sort:change', fn);
+
+    const sort = [{ columnId: 'age', direction: 'asc' as const }];
+    grid.sortState.set(sort);
+    expect(fn).toHaveBeenCalledWith({ sort });
+  });
+
+  it('emits filter:change event when filterState changes', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    const fn = vi.fn();
+    grid.events.on('filter:change', fn);
+
+    const filter = [{ columnId: 'city', operator: 'eq' as const, value: 'Seoul' }];
+    grid.filterState.set(filter);
+    expect(fn).toHaveBeenCalledWith({ filter });
+  });
+
+  it('columns signal is subscribable', () => {
+    const grid = createGrid({ data: sampleData, columns: sampleColumns });
+    const fn = vi.fn();
+    grid.columns.subscribe(fn);
+
+    grid.setColumns([{ id: 'x', header: 'X' }]);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/grid.ts
+++ b/packages/core/src/grid.ts
@@ -1,0 +1,149 @@
+import { createEventBus } from './events';
+import { buildIndexMap } from './index-map';
+import { createPluginManager } from './plugin';
+import { signal, computed, batch } from './signal';
+import type { Unsubscribe } from './signal';
+import type {
+  GridOptions,
+  GridInstance,
+  GridEvents,
+  Row,
+  ColumnDef,
+  CellValue,
+  CellDecoration,
+  SortState,
+  FilterState,
+} from './types';
+
+export function createGrid(options: GridOptions): GridInstance {
+  const { columns: initialColumns, plugins: initialPlugins = [] } = options;
+
+  // Copy-on-init per RFC-001: shallow copy each row to avoid mutating caller's objects
+  let data: Row[] = options.data.map((row) => ({ ...row }));
+
+  // Reactive state
+  const columns = signal<ColumnDef[]>([...initialColumns]);
+  const sortState = signal<SortState>([]);
+  const filterState = signal<FilterState>([]);
+
+  // Event bus
+  const events = createEventBus<GridEvents>();
+
+  // Index map: recomputed when sort/filter/data changes
+  const dataVersion = signal(0);
+  const indexMap = computed(() => {
+    dataVersion.get(); // track data changes
+    return buildIndexMap(data, sortState.get(), filterState.get());
+  });
+
+  // Emit events when sort/filter state changes
+  sortState.subscribe((sort) => {
+    events.emit('sort:change', { sort });
+  });
+  filterState.subscribe((filter) => {
+    events.emit('filter:change', { filter });
+  });
+
+  // Plugin manager
+  const pluginManager = createPluginManager(initialPlugins);
+
+  let destroyed = false;
+
+  const assertAlive = () => {
+    if (destroyed) throw new Error('Grid instance has been destroyed');
+  };
+
+  const grid: GridInstance = {
+    get data(): Row[] {
+      return [...data];
+    },
+
+    columns,
+    sortState,
+    filterState,
+    indexMap,
+
+    get rowCount() {
+      return indexMap.get().length;
+    },
+
+    events,
+
+    getCell(rowIndex: number, columnId: string): CellValue {
+      assertAlive();
+      const dataIndex = indexMap.get().viewToData(rowIndex);
+      const row = data[dataIndex];
+      if (!row) throw new RangeError(`Data index ${dataIndex} out of range`);
+      return row[columnId];
+    },
+
+    setCell(rowIndex: number, columnId: string, value: CellValue): void {
+      assertAlive();
+      const dataIndex = indexMap.get().viewToData(rowIndex);
+      const row = data[dataIndex];
+      if (!row) throw new RangeError(`Data index ${dataIndex} out of range`);
+      const oldValue = row[columnId];
+      if (Object.is(oldValue, value)) return;
+
+      row[columnId] = value;
+      dataVersion.update((v) => v + 1);
+      events.emit('data:change', {
+        changes: [{ row: dataIndex, col: columnId, oldValue, newValue: value }],
+      });
+    },
+
+    setData(newData: Row[]): void {
+      assertAlive();
+      data = newData.map((row) => ({ ...row }));
+      dataVersion.update((v) => v + 1);
+      events.emit('data:rowsUpdate', { data });
+    },
+
+    setColumns(newColumns: ColumnDef[]): void {
+      assertAlive();
+      columns.set([...newColumns]);
+      events.emit('columns:update', { columns: columns.get() });
+    },
+
+    batchUpdate(fn: () => void): void {
+      batch(fn);
+    },
+
+    getPlugin<T>(name: string): T | undefined {
+      return pluginManager.getPlugin<T>(name);
+    },
+
+    getCellDecorations(row: number, col: string): CellDecoration[] {
+      const value = grid.getCell(row, col);
+      const result: CellDecoration[] = [];
+      for (const decorator of pluginManager.decorators) {
+        const decoration = decorator({ row, col, value });
+        if (decoration) {
+          result.push(decoration);
+        }
+      }
+      return result;
+    },
+
+    subscribe<K extends keyof GridEvents & string>(
+      event: K,
+      handler: (payload: GridEvents[K]) => void,
+    ): Unsubscribe {
+      return events.on(event, handler);
+    },
+
+    destroy(): void {
+      if (destroyed) return;
+      destroyed = true;
+      events.emit('destroy', undefined);
+      pluginManager.destroyAll();
+      events.removeAllListeners();
+    },
+  };
+
+  // Initialize plugins after grid is constructed
+  pluginManager.initAll(grid, events);
+  events.emit('ready', undefined);
+
+  return grid;
+}

--- a/packages/core/src/index-map.spec.ts
+++ b/packages/core/src/index-map.spec.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildIndexMap } from './index-map';
+import type { Row } from './types';
+
+const data: Row[] = [
+  { name: 'Alice', age: 30, city: 'Seoul' },
+  { name: 'Bob', age: 25, city: 'Tokyo' },
+  { name: 'Charlie', age: 35, city: 'Seoul' },
+];
+
+describe('buildIndexMap', () => {
+  it('returns identity map with no sort/filter', () => {
+    const map = buildIndexMap(data, [], []);
+    expect(map.length).toBe(3);
+    expect(map.viewToData(0)).toBe(0);
+    expect(map.viewToData(1)).toBe(1);
+    expect(map.viewToData(2)).toBe(2);
+  });
+
+  it('handles empty data', () => {
+    const map = buildIndexMap([], [], []);
+    expect(map.length).toBe(0);
+  });
+
+  it('throws RangeError for out-of-bounds viewToData', () => {
+    const map = buildIndexMap(data, [], []);
+    expect(() => map.viewToData(-1)).toThrow(RangeError);
+    expect(() => map.viewToData(3)).toThrow(RangeError);
+  });
+
+  it('throws RangeError on empty data viewToData', () => {
+    const map = buildIndexMap([], [], []);
+    expect(() => map.viewToData(0)).toThrow(RangeError);
+  });
+
+  it('returns null for non-existent dataToView', () => {
+    const map = buildIndexMap(data, [], []);
+    expect(map.dataToView(999)).toBeNull();
+  });
+
+  describe('sort', () => {
+    it('sorts ascending', () => {
+      const map = buildIndexMap(data, [{ columnId: 'age', direction: 'asc' }], []);
+      expect(map.viewToData(0)).toBe(1); // Bob 25
+      expect(map.viewToData(1)).toBe(0); // Alice 30
+      expect(map.viewToData(2)).toBe(2); // Charlie 35
+    });
+
+    it('sorts descending', () => {
+      const map = buildIndexMap(data, [{ columnId: 'age', direction: 'desc' }], []);
+      expect(map.viewToData(0)).toBe(2); // Charlie 35
+      expect(map.viewToData(2)).toBe(1); // Bob 25
+    });
+
+    it('handles null values in sort (nulls first)', () => {
+      const withNulls: Row[] = [
+        { name: 'Alice', age: 30 },
+        { name: 'Bob', age: null },
+        { name: 'Charlie', age: 25 },
+      ];
+      const map = buildIndexMap(withNulls, [{ columnId: 'age', direction: 'asc' }], []);
+      expect(map.viewToData(0)).toBe(1); // Bob null (first)
+      expect(map.viewToData(1)).toBe(2); // Charlie 25
+      expect(map.viewToData(2)).toBe(0); // Alice 30
+    });
+
+    it('multi-column sort', () => {
+      const tied: Row[] = [
+        { name: 'Bob', age: 30 },
+        { name: 'Alice', age: 30 },
+        { name: 'Charlie', age: 25 },
+      ];
+      const map = buildIndexMap(
+        tied,
+        [
+          { columnId: 'age', direction: 'asc' },
+          { columnId: 'name', direction: 'asc' },
+        ],
+        [],
+      );
+      expect(map.viewToData(0)).toBe(2); // Charlie 25
+      expect(map.viewToData(1)).toBe(1); // Alice 30
+      expect(map.viewToData(2)).toBe(0); // Bob 30
+    });
+  });
+
+  describe('filter', () => {
+    it('filters by equality', () => {
+      const map = buildIndexMap(data, [], [{ columnId: 'city', operator: 'eq', value: 'Seoul' }]);
+      expect(map.length).toBe(2);
+      expect(map.viewToData(0)).toBe(0); // Alice
+      expect(map.viewToData(1)).toBe(2); // Charlie
+    });
+
+    it('filters by neq', () => {
+      const map = buildIndexMap(data, [], [{ columnId: 'city', operator: 'neq', value: 'Seoul' }]);
+      expect(map.length).toBe(1);
+      expect(map.viewToData(0)).toBe(1); // Bob
+    });
+
+    it('filters by contains', () => {
+      const map = buildIndexMap(
+        data,
+        [],
+        [{ columnId: 'name', operator: 'contains', value: 'li' }],
+      );
+      expect(map.length).toBe(2); // Alice, Charlie
+    });
+
+    it('filters by startsWith', () => {
+      const map = buildIndexMap(
+        data,
+        [],
+        [{ columnId: 'name', operator: 'startsWith', value: 'A' }],
+      );
+      expect(map.length).toBe(1);
+      expect(map.viewToData(0)).toBe(0); // Alice
+    });
+
+    it('filters by endsWith', () => {
+      const map = buildIndexMap(
+        data,
+        [],
+        [{ columnId: 'name', operator: 'endsWith', value: 'ob' }],
+      );
+      expect(map.length).toBe(1);
+      expect(map.viewToData(0)).toBe(1); // Bob
+    });
+
+    it('filters by gt/gte/lt/lte', () => {
+      const gtMap = buildIndexMap(data, [], [{ columnId: 'age', operator: 'gt', value: 25 }]);
+      expect(gtMap.length).toBe(2); // Alice 30, Charlie 35
+
+      const gteMap = buildIndexMap(data, [], [{ columnId: 'age', operator: 'gte', value: 30 }]);
+      expect(gteMap.length).toBe(2); // Alice 30, Charlie 35
+
+      const ltMap = buildIndexMap(data, [], [{ columnId: 'age', operator: 'lt', value: 35 }]);
+      expect(ltMap.length).toBe(2); // Alice 30, Bob 25
+
+      const lteMap = buildIndexMap(data, [], [{ columnId: 'age', operator: 'lte', value: 25 }]);
+      expect(lteMap.length).toBe(1); // Bob 25
+    });
+
+    it('handles null value in eq filter', () => {
+      const withNulls: Row[] = [
+        { name: 'Alice', city: null },
+        { name: 'Bob', city: 'Seoul' },
+      ];
+      const map = buildIndexMap(withNulls, [], [{ columnId: 'city', operator: 'eq', value: null }]);
+      expect(map.length).toBe(1);
+      expect(map.viewToData(0)).toBe(0);
+    });
+
+    it('multiple filters (AND logic)', () => {
+      const map = buildIndexMap(
+        data,
+        [],
+        [
+          { columnId: 'city', operator: 'eq', value: 'Seoul' },
+          { columnId: 'age', operator: 'gt', value: 30 },
+        ],
+      );
+      expect(map.length).toBe(1); // Charlie only
+      expect(map.viewToData(0)).toBe(2);
+    });
+
+    it('filter that excludes all rows', () => {
+      const map = buildIndexMap(data, [], [{ columnId: 'city', operator: 'eq', value: 'Nowhere' }]);
+      expect(map.length).toBe(0);
+    });
+  });
+
+  describe('sort + filter combined', () => {
+    it('filters then sorts', () => {
+      const map = buildIndexMap(
+        data,
+        [{ columnId: 'age', direction: 'desc' }],
+        [{ columnId: 'city', operator: 'eq', value: 'Seoul' }],
+      );
+      expect(map.length).toBe(2);
+      expect(map.viewToData(0)).toBe(2); // Charlie 35
+      expect(map.viewToData(1)).toBe(0); // Alice 30
+    });
+  });
+
+  describe('dataToView', () => {
+    it('reverse maps correctly', () => {
+      const map = buildIndexMap(data, [{ columnId: 'age', direction: 'asc' }], []);
+      expect(map.dataToView(0)).toBe(1); // Alice is at view index 1
+      expect(map.dataToView(1)).toBe(0); // Bob is at view index 0
+      expect(map.dataToView(2)).toBe(2); // Charlie is at view index 2
+    });
+
+    it('returns null for filtered-out rows', () => {
+      const map = buildIndexMap(data, [], [{ columnId: 'city', operator: 'eq', value: 'Seoul' }]);
+      expect(map.dataToView(1)).toBeNull(); // Bob is filtered out
+    });
+  });
+});

--- a/packages/core/src/index-map.ts
+++ b/packages/core/src/index-map.ts
@@ -1,0 +1,100 @@
+import type { CellValue, FilterEntry, FilterState, IndexMap, Row, SortState } from './types';
+
+function compareValues(a: CellValue, b: CellValue): number {
+  if (a == null && b == null) return 0;
+  if (a == null) return -1;
+  if (b == null) return 1;
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function matchesFilter(value: CellValue, filter: FilterEntry): boolean {
+  const { operator, value: filterValue } = filter;
+
+  if (value == null) {
+    return operator === 'eq' && filterValue == null;
+  }
+
+  switch (operator) {
+    case 'eq':
+      return value === filterValue;
+    case 'neq':
+      return value !== filterValue;
+    case 'gt':
+      return compareValues(value, filterValue) > 0;
+    case 'gte':
+      return compareValues(value, filterValue) >= 0;
+    case 'lt':
+      return compareValues(value, filterValue) < 0;
+    case 'lte':
+      return compareValues(value, filterValue) <= 0;
+    case 'contains':
+      return String(value).includes(String(filterValue));
+    case 'startsWith':
+      return String(value).startsWith(String(filterValue));
+    case 'endsWith':
+      return String(value).endsWith(String(filterValue));
+    default:
+      return true;
+  }
+}
+
+export function buildIndexMap(
+  data: Row[],
+  sortState: SortState,
+  filterState: FilterState,
+): IndexMap {
+  // 1. Filter: collect indices of rows that pass all filters
+  let indices = Array.from({ length: data.length }, (_, i) => i);
+
+  if (filterState.length > 0) {
+    indices = indices.filter((dataIndex) => {
+      const row = data[dataIndex];
+      if (!row) return false;
+      return filterState.every((f) => matchesFilter(row[f.columnId], f));
+    });
+  }
+
+  // 2. Sort
+  if (sortState.length > 0) {
+    indices.sort((a, b) => {
+      const rowA = data[a];
+      const rowB = data[b];
+      if (!rowA || !rowB) return 0;
+
+      for (const entry of sortState) {
+        const cmp = compareValues(rowA[entry.columnId], rowB[entry.columnId]);
+        if (cmp !== 0) {
+          return entry.direction === 'desc' ? -cmp : cmp;
+        }
+      }
+      return 0;
+    });
+  }
+
+  // 3. Build reverse map (dataIndex → viewIndex)
+  const dataToViewMap = new Map<number, number>();
+  for (let viewIdx = 0; viewIdx < indices.length; viewIdx++) {
+    const dataIdx = indices[viewIdx];
+    if (dataIdx !== undefined) {
+      dataToViewMap.set(dataIdx, viewIdx);
+    }
+  }
+
+  return {
+    viewToData(viewIndex: number): number {
+      if (viewIndex < 0 || viewIndex >= indices.length) {
+        throw new RangeError(`View index ${viewIndex} out of range [0, ${indices.length})`);
+      }
+      // Safe: bounds checked above
+      return indices[viewIndex] as number;
+    },
+    dataToView(dataIndex: number): number | null {
+      return dataToViewMap.get(dataIndex) ?? null;
+    },
+    get length() {
+      return indices.length;
+    },
+  };
+}

--- a/packages/core/src/index.spec.ts
+++ b/packages/core/src/index.spec.ts
@@ -1,9 +1,23 @@
 import { describe, expect, it } from 'vitest';
 
-import { VERSION } from './index';
+import { VERSION, createGrid, signal, computed, batch, createEventBus } from './index';
 
-describe('core', () => {
+describe('core exports', () => {
   it('exports VERSION', () => {
     expect(VERSION).toBe('0.0.0');
+  });
+
+  it('exports createGrid', () => {
+    expect(typeof createGrid).toBe('function');
+  });
+
+  it('exports signal primitives', () => {
+    expect(typeof signal).toBe('function');
+    expect(typeof computed).toBe('function');
+    expect(typeof batch).toBe('function');
+  });
+
+  it('exports createEventBus', () => {
+    expect(typeof createEventBus).toBe('function');
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,38 @@
 export const VERSION = '0.0.0';
+
+// Core API
+export { createGrid } from './grid';
+
+// Reactive primitives
+export { signal, computed, batch } from './signal';
+export type { Signal, Computed, ReadonlySignal, Unsubscribe } from './signal';
+
+// Event bus
+export { createEventBus } from './events';
+export type { EventBus, EventHandler } from './events';
+
+// Types
+export type {
+  CellValue,
+  Row,
+  ColumnType,
+  PinPosition,
+  ColumnDef,
+  SortDirection,
+  SortEntry,
+  SortState,
+  FilterEntry,
+  FilterOperator,
+  FilterState,
+  IndexMap,
+  ViewportState,
+  VisibleRange,
+  CellChange,
+  GridEvents,
+  CellDecoration,
+  CellDecorator,
+  PluginContext,
+  GridPlugin,
+  GridOptions,
+  GridInstance,
+} from './types';

--- a/packages/core/src/plugin.spec.ts
+++ b/packages/core/src/plugin.spec.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createGrid } from './grid';
+import { resolvePluginOrder } from './plugin';
+import type { GridPlugin } from './types';
+
+describe('resolvePluginOrder', () => {
+  it('returns plugins in order when no dependencies', () => {
+    const a: GridPlugin = { name: 'a', init: vi.fn() };
+    const b: GridPlugin = { name: 'b', init: vi.fn() };
+    const result = resolvePluginOrder([a, b]);
+    expect(result.map((p) => p.name)).toEqual(['a', 'b']);
+  });
+
+  it('sorts by dependencies', () => {
+    const a: GridPlugin = { name: 'a', dependencies: ['b'], init: vi.fn() };
+    const b: GridPlugin = { name: 'b', init: vi.fn() };
+    const result = resolvePluginOrder([a, b]);
+    expect(result.map((p) => p.name)).toEqual(['b', 'a']);
+  });
+
+  it('handles deep dependency chains', () => {
+    const a: GridPlugin = { name: 'a', dependencies: ['b'], init: vi.fn() };
+    const b: GridPlugin = { name: 'b', dependencies: ['c'], init: vi.fn() };
+    const c: GridPlugin = { name: 'c', init: vi.fn() };
+    const result = resolvePluginOrder([a, b, c]);
+    expect(result.map((p) => p.name)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('throws on circular dependencies', () => {
+    const a: GridPlugin = { name: 'a', dependencies: ['b'], init: vi.fn() };
+    const b: GridPlugin = { name: 'b', dependencies: ['a'], init: vi.fn() };
+    expect(() => resolvePluginOrder([a, b])).toThrow(/Circular/);
+  });
+
+  it('throws on missing dependency', () => {
+    const a: GridPlugin = { name: 'a', dependencies: ['missing'], init: vi.fn() };
+    expect(() => resolvePluginOrder([a])).toThrow(/missing/);
+  });
+
+  it('throws on duplicate names', () => {
+    const a1: GridPlugin = { name: 'a', init: vi.fn() };
+    const a2: GridPlugin = { name: 'a', init: vi.fn() };
+    expect(() => resolvePluginOrder([a1, a2])).toThrow(/Duplicate/);
+  });
+});
+
+describe('createPluginManager', () => {
+  it('initializes plugins and exposes APIs', () => {
+    const plugin: GridPlugin = {
+      name: 'test',
+      init(ctx) {
+        ctx.expose('test', { hello: () => 'world' });
+      },
+    };
+
+    const grid = createGrid({
+      data: [],
+      columns: [],
+      plugins: [plugin],
+    });
+
+    const api = grid.getPlugin<{ hello: () => string }>('test');
+    expect(api?.hello()).toBe('world');
+  });
+
+  it('destroys plugins in reverse order', () => {
+    const order: string[] = [];
+    const a: GridPlugin = {
+      name: 'a',
+      init: () => () => order.push('a'),
+    };
+    const b: GridPlugin = {
+      name: 'b',
+      init: () => () => order.push('b'),
+    };
+
+    const grid = createGrid({ data: [], columns: [], plugins: [a, b] });
+    grid.destroy();
+
+    expect(order).toEqual(['b', 'a']);
+  });
+
+  it('plugins can access each other via getPlugin', () => {
+    const provider: GridPlugin = {
+      name: 'provider',
+      init(ctx) {
+        ctx.expose('provider', { value: 42 });
+      },
+    };
+
+    let receivedValue: number | undefined;
+    const consumer: GridPlugin = {
+      name: 'consumer',
+      dependencies: ['provider'],
+      init(ctx) {
+        const p = ctx.getPlugin<{ value: number }>('provider');
+        receivedValue = p?.value;
+      },
+    };
+
+    createGrid({ data: [], columns: [], plugins: [provider, consumer] });
+    expect(receivedValue).toBe(42);
+  });
+
+  it('plugins can add cell decorators', () => {
+    const plugin: GridPlugin = {
+      name: 'highlight',
+      init(ctx) {
+        ctx.addCellDecorator((cell) => {
+          if (cell.value === 'special') {
+            return { className: 'highlighted' };
+          }
+          return null;
+        });
+      },
+    };
+
+    const grid = createGrid({
+      data: [{ name: 'special' }, { name: 'normal' }],
+      columns: [{ id: 'name', header: 'Name' }],
+      plugins: [plugin],
+    });
+
+    const decs = grid.getCellDecorations(0, 'name');
+    expect(decs).toHaveLength(1);
+    expect(decs[0]!.className).toBe('highlighted');
+
+    const decs2 = grid.getCellDecorations(1, 'name');
+    expect(decs2).toHaveLength(0);
+  });
+
+  it('emits plugin:ready for each plugin', () => {
+    const readyNames: string[] = [];
+    const plugin: GridPlugin = {
+      name: 'test-plugin',
+      init(ctx) {
+        ctx.events.on('plugin:ready', ({ name }) => {
+          readyNames.push(name);
+        });
+      },
+    };
+
+    const plugin2: GridPlugin = {
+      name: 'second',
+      dependencies: ['test-plugin'],
+      init: vi.fn(),
+    };
+
+    createGrid({ data: [], columns: [], plugins: [plugin, plugin2] });
+    // plugin receives ready event for second (not itself, since it subscribes after its own init)
+    expect(readyNames).toContain('second');
+  });
+});

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -1,0 +1,109 @@
+import type { EventBus } from './events';
+import type { GridPlugin, PluginContext, CellDecorator, GridInstance, GridEvents } from './types';
+
+interface PluginEntry {
+  plugin: GridPlugin;
+  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+  cleanup?: (() => void) | void;
+}
+
+export interface PluginManager {
+  readonly apis: Map<string, unknown>;
+  readonly decorators: CellDecorator[];
+  initAll(grid: GridInstance, events: EventBus<GridEvents>): void;
+  getPlugin<T>(name: string): T | undefined;
+  destroyAll(): void;
+}
+
+export function resolvePluginOrder(plugins: GridPlugin[]): GridPlugin[] {
+  const byName = new Map<string, GridPlugin>();
+  for (const p of plugins) {
+    if (byName.has(p.name)) {
+      throw new Error(`Duplicate plugin name: "${p.name}"`);
+    }
+    byName.set(p.name, p);
+  }
+
+  const sorted: GridPlugin[] = [];
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+
+  const visit = (plugin: GridPlugin) => {
+    if (visited.has(plugin.name)) return;
+    if (visiting.has(plugin.name)) {
+      throw new Error(`Circular plugin dependency: "${plugin.name}"`);
+    }
+
+    visiting.add(plugin.name);
+
+    for (const dep of plugin.dependencies ?? []) {
+      const depPlugin = byName.get(dep);
+      if (!depPlugin) {
+        throw new Error(`Plugin "${plugin.name}" depends on "${dep}", which is not registered`);
+      }
+      visit(depPlugin);
+    }
+
+    visiting.delete(plugin.name);
+    visited.add(plugin.name);
+    sorted.push(plugin);
+  };
+
+  for (const p of plugins) {
+    visit(p);
+  }
+
+  return sorted;
+}
+
+export function createPluginManager(plugins: GridPlugin[]): PluginManager {
+  const ordered = resolvePluginOrder(plugins);
+  const entries: PluginEntry[] = [];
+  const apis = new Map<string, unknown>();
+  const decorators: CellDecorator[] = [];
+
+  return {
+    apis,
+    decorators,
+
+    initAll(grid: GridInstance, events: EventBus<GridEvents>) {
+      for (const plugin of ordered) {
+        const ctx: PluginContext = {
+          grid,
+          events,
+          getPlugin<T>(name: string): T | undefined {
+            return apis.get(name) as T | undefined;
+          },
+          expose(name: string, api: unknown) {
+            apis.set(name, api);
+          },
+          addCellDecorator(decorator: CellDecorator) {
+            decorators.push(decorator);
+          },
+        };
+
+        const cleanup = plugin.init(ctx);
+        entries.push({ plugin, cleanup });
+        events.emit('plugin:ready', { name: plugin.name });
+      }
+    },
+
+    getPlugin<T>(name: string): T | undefined {
+      return apis.get(name) as T | undefined;
+    },
+
+    destroyAll() {
+      // Destroy in reverse order
+      for (let i = entries.length - 1; i >= 0; i--) {
+        const entry = entries[i];
+        if (!entry) continue;
+        if (typeof entry.cleanup === 'function') {
+          entry.cleanup();
+        }
+      }
+      entries.length = 0;
+      apis.clear();
+      decorators.length = 0;
+    },
+  };
+}

--- a/packages/core/src/signal.spec.ts
+++ b/packages/core/src/signal.spec.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { signal, computed, batch } from './signal';
+
+describe('signal', () => {
+  it('stores and retrieves a value', () => {
+    const s = signal(42);
+    expect(s.get()).toBe(42);
+  });
+
+  it('updates value with set()', () => {
+    const s = signal('hello');
+    s.set('world');
+    expect(s.get()).toBe('world');
+  });
+
+  it('updates value with update()', () => {
+    const s = signal(10);
+    s.update((v) => v + 5);
+    expect(s.get()).toBe(15);
+  });
+
+  it('notifies subscribers on change', () => {
+    const s = signal(0);
+    const fn = vi.fn();
+    s.subscribe(fn);
+
+    s.set(1);
+    expect(fn).toHaveBeenCalledWith(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not notify when value is the same (Object.is)', () => {
+    const s = signal(1);
+    const fn = vi.fn();
+    s.subscribe(fn);
+
+    s.set(1);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribes correctly', () => {
+    const s = signal(0);
+    const fn = vi.fn();
+    const unsub = s.subscribe(fn);
+
+    s.set(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    unsub();
+    s.set(2);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('peek() reads without tracking', () => {
+    const s = signal(5);
+    expect(s.peek()).toBe(5);
+  });
+
+  it('supports multiple subscribers', () => {
+    const s = signal(0);
+    const fn1 = vi.fn();
+    const fn2 = vi.fn();
+    s.subscribe(fn1);
+    s.subscribe(fn2);
+
+    s.set(1);
+    expect(fn1).toHaveBeenCalledWith(1);
+    expect(fn2).toHaveBeenCalledWith(1);
+  });
+});
+
+describe('computed', () => {
+  it('derives value from signals', () => {
+    const a = signal(2);
+    const b = signal(3);
+    const sum = computed(() => a.get() + b.get());
+
+    expect(sum.get()).toBe(5);
+  });
+
+  it('recomputes when dependency changes', () => {
+    const a = signal(1);
+    const doubled = computed(() => a.get() * 2);
+
+    expect(doubled.get()).toBe(2);
+    a.set(5);
+    expect(doubled.get()).toBe(10);
+  });
+
+  it('notifies subscribers when value changes', () => {
+    const a = signal(1);
+    const doubled = computed(() => a.get() * 2);
+    const fn = vi.fn();
+
+    doubled.subscribe(fn);
+    a.set(3);
+    expect(fn).toHaveBeenCalledWith(6);
+  });
+
+  it('is lazy - does not compute until read', () => {
+    const fn = vi.fn(() => 42);
+    const c = computed(fn);
+
+    expect(fn).not.toHaveBeenCalled();
+    c.get();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('peek() reads without tracking', () => {
+    const a = signal(3);
+    const c = computed(() => a.get() + 1);
+    expect(c.peek()).toBe(4);
+  });
+
+  it('chains computed values', () => {
+    const a = signal(1);
+    const b = computed(() => a.get() * 2);
+    const c = computed(() => b.get() + 10);
+
+    expect(c.get()).toBe(12);
+    a.set(5);
+    expect(c.get()).toBe(20);
+  });
+
+  it('unsubscribes from computed', () => {
+    const a = signal(1);
+    const c = computed(() => a.get() * 2);
+    const fn = vi.fn();
+
+    const unsub = c.subscribe(fn);
+    a.set(2);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    unsub();
+    a.set(3);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('batch', () => {
+  it('defers notifications until batch completes', () => {
+    const a = signal(1);
+    const b = signal(2);
+    const fn = vi.fn();
+    a.subscribe(fn);
+    b.subscribe(fn);
+
+    batch(() => {
+      a.set(10);
+      b.set(20);
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('notifies computed subscribers after batch', () => {
+    const a = signal(1);
+    const b = signal(2);
+    const sum = computed(() => a.get() + b.get());
+    const fn = vi.fn();
+    sum.subscribe(fn);
+
+    batch(() => {
+      a.set(10);
+      b.set(20);
+    });
+
+    expect(sum.get()).toBe(30);
+  });
+
+  it('supports nested batches', () => {
+    const s = signal(0);
+    const fn = vi.fn();
+    s.subscribe(fn);
+
+    batch(() => {
+      s.set(1);
+      batch(() => {
+        s.set(2);
+      });
+      // inner batch does not flush
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    // only outermost batch flushes
+    expect(fn).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/signal.ts
+++ b/packages/core/src/signal.ts
@@ -1,0 +1,171 @@
+export type Unsubscribe = () => void;
+
+export interface ReadonlySignal<T> {
+  get(): T;
+  peek(): T;
+  subscribe(fn: (value: T) => void): Unsubscribe;
+}
+
+export interface Signal<T> extends ReadonlySignal<T> {
+  set(value: T): void;
+  update(fn: (current: T) => T): void;
+}
+
+export type Computed<T> = ReadonlySignal<T>;
+
+let batchDepth = 0;
+const pendingEffects: Set<() => void> = new Set();
+
+export function batch(fn: () => void): void {
+  batchDepth++;
+  try {
+    fn();
+  } finally {
+    batchDepth--;
+    if (batchDepth === 0) {
+      const effects = [...pendingEffects];
+      pendingEffects.clear();
+      for (const effect of effects) {
+        effect();
+      }
+    }
+  }
+}
+
+let activeComputed: Set<ReadonlySignal<unknown>> | null = null;
+
+export function signal<T>(initialValue: T): Signal<T> {
+  let value = initialValue;
+  const subscribers = new Set<(value: T) => void>();
+
+  const notify = () => {
+    // Snapshot subscribers to avoid issues with mutations during iteration
+    const snapshot = [...subscribers];
+    for (const fn of snapshot) {
+      fn(value);
+    }
+  };
+
+  const s: Signal<T> = {
+    get() {
+      if (activeComputed) {
+        activeComputed.add(s as ReadonlySignal<unknown>);
+      }
+      return value;
+    },
+    peek() {
+      return value;
+    },
+    set(newValue: T) {
+      if (Object.is(value, newValue)) return;
+      value = newValue;
+      if (batchDepth > 0) {
+        pendingEffects.add(notify);
+      } else {
+        notify();
+      }
+    },
+    update(fn: (current: T) => T) {
+      s.set(fn(value));
+    },
+    subscribe(fn: (value: T) => void): Unsubscribe {
+      subscribers.add(fn);
+      return () => {
+        subscribers.delete(fn);
+      };
+    },
+  };
+
+  return s;
+}
+
+export function computed<T>(fn: () => T): Computed<T> {
+  let value: T;
+  let dirty = true;
+  const subscribers = new Set<(value: T) => void>();
+  let depUnsubs: Unsubscribe[] = [];
+  let computing = false;
+
+  const unsubDeps = () => {
+    for (const unsub of depUnsubs) {
+      unsub();
+    }
+    depUnsubs = [];
+  };
+
+  const recompute = (): T => {
+    unsubDeps();
+
+    const prevActive = activeComputed;
+    activeComputed = new Set();
+    computing = true;
+    try {
+      value = fn();
+      dirty = false;
+    } finally {
+      const newDeps = activeComputed;
+      activeComputed = prevActive;
+      computing = false;
+
+      // Subscribe to new deps
+      for (const dep of newDeps) {
+        depUnsubs.push(dep.subscribe(onDepChange));
+      }
+    }
+
+    return value;
+  };
+
+  const onDepChange = () => {
+    // Avoid reentrant computation
+    if (computing) return;
+
+    const oldValue = value;
+    dirty = true;
+    const newValue = recompute();
+
+    // Only notify if value actually changed
+    if (!Object.is(oldValue, newValue)) {
+      const snapshot = [...subscribers];
+      const doNotify = () => {
+        for (const sub of snapshot) {
+          sub(newValue);
+        }
+      };
+      if (batchDepth > 0) {
+        pendingEffects.add(doNotify);
+      } else {
+        doNotify();
+      }
+    }
+  };
+
+  const c: Computed<T> = {
+    get() {
+      if (activeComputed) {
+        activeComputed.add(c as ReadonlySignal<unknown>);
+      }
+      if (dirty) {
+        recompute();
+      }
+      return value;
+    },
+    peek() {
+      if (dirty) {
+        recompute();
+      }
+      return value;
+    },
+    subscribe(sub: (value: T) => void): Unsubscribe {
+      if (dirty) {
+        recompute();
+      }
+      subscribers.add(sub);
+      return () => {
+        subscribers.delete(sub);
+      };
+    },
+  };
+
+  return c;
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,0 +1,185 @@
+import type { EventBus } from './events';
+import type { Signal, Computed, ReadonlySignal, Unsubscribe } from './signal';
+
+// ─── Cell & Data ───────────────────────────────────────────
+
+export type CellValue = string | number | boolean | Date | null | undefined;
+
+export type Row = Record<string, CellValue>;
+
+// ─── Column Definition ─────────────────────────────────────
+
+export type ColumnType = 'text' | 'number' | 'date' | 'select' | 'checkbox';
+
+export type PinPosition = 'left' | 'right' | false;
+
+export interface ColumnDef {
+  id: string;
+  header: string;
+  width?: number;
+  minWidth?: number;
+  maxWidth?: number;
+  type?: ColumnType;
+  pin?: PinPosition;
+  sortable?: boolean;
+  filterable?: boolean;
+  resizable?: boolean;
+  visible?: boolean;
+}
+
+// ─── Sort & Filter ─────────────────────────────────────────
+
+export type SortDirection = 'asc' | 'desc';
+
+export interface SortEntry {
+  columnId: string;
+  direction: SortDirection;
+}
+
+export type SortState = SortEntry[];
+
+export interface FilterEntry {
+  columnId: string;
+  operator: FilterOperator;
+  value: CellValue;
+}
+
+export type FilterOperator =
+  | 'eq'
+  | 'neq'
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte'
+  | 'contains'
+  | 'startsWith'
+  | 'endsWith';
+
+export type FilterState = FilterEntry[];
+
+// ─── Index Map ─────────────────────────────────────────────
+
+export interface IndexMap {
+  viewToData(viewIndex: number): number;
+  dataToView(dataIndex: number): number | null;
+  readonly length: number;
+}
+
+// ─── Viewport ──────────────────────────────────────────────
+
+export interface ViewportState {
+  scrollTop: number;
+  scrollLeft: number;
+  containerWidth: number;
+  containerHeight: number;
+}
+
+export interface VisibleRange {
+  rowStart: number;
+  rowEnd: number;
+  colStart: number;
+  colEnd: number;
+}
+
+// ─── Cell Change ───────────────────────────────────────────
+
+export interface CellChange {
+  row: number;
+  col: string;
+  oldValue: CellValue;
+  newValue: CellValue;
+}
+
+// ─── Grid Events ───────────────────────────────────────────
+
+export interface GridEvents {
+  'data:change': { changes: CellChange[] };
+  'data:rowsUpdate': { data: Row[] };
+  'columns:update': { columns: ColumnDef[] };
+  'sort:change': { sort: SortState };
+  'filter:change': { filter: FilterState };
+  'viewport:change': { viewport: ViewportState };
+  'plugin:ready': { name: string };
+  ready: undefined;
+  destroy: undefined;
+}
+
+// ─── Plugin ────────────────────────────────────────────────
+
+export interface CellDecoration {
+  className?: string;
+  style?: Record<string, string>;
+  attributes?: Record<string, string>;
+}
+
+export type CellDecorator = (cell: {
+  row: number;
+  col: string;
+  value: CellValue;
+}) => CellDecoration | null;
+
+export interface PluginContext {
+  grid: GridInstance;
+  events: EventBus<GridEvents>;
+  getPlugin<T>(name: string): T | undefined;
+  expose(name: string, api: unknown): void;
+  addCellDecorator(decorator: CellDecorator): void;
+}
+
+export interface GridPlugin {
+  name: string;
+  dependencies?: string[];
+  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+  init(ctx: PluginContext): (() => void) | void;
+}
+
+// ─── Grid Options ──────────────────────────────────────────
+
+export interface GridOptions {
+  data: Row[];
+  columns: ColumnDef[];
+  plugins?: GridPlugin[];
+}
+
+// ─── Grid Instance ─────────────────────────────────────────
+
+export interface GridInstance {
+  // State access
+  readonly data: Row[];
+  readonly columns: ReadonlySignal<ColumnDef[]>;
+  readonly sortState: Signal<SortState>;
+  readonly filterState: Signal<FilterState>;
+  readonly indexMap: Computed<IndexMap>;
+
+  // Cell operations
+  getCell(rowIndex: number, columnId: string): CellValue;
+  setCell(rowIndex: number, columnId: string, value: CellValue): void;
+
+  // Data operations
+  setData(data: Row[]): void;
+  setColumns(columns: ColumnDef[]): void;
+
+  // Batch updates
+  batchUpdate(fn: () => void): void;
+
+  // Events
+  readonly events: EventBus<GridEvents>;
+
+  // Plugin access
+  getPlugin<T>(name: string): T | undefined;
+
+  // Cell decorators
+  getCellDecorations(row: number, col: string): CellDecoration[];
+
+  // Row count (view)
+  readonly rowCount: number;
+
+  // Lifecycle
+  destroy(): void;
+
+  // Subscribe helper
+  subscribe<K extends keyof GridEvents & string>(
+    event: K,
+    handler: (payload: GridEvents[K]) => void,
+  ): Unsubscribe;
+}


### PR DESCRIPTION
## Summary

Implements **#2 — Headless core: state management, column/row model**.

- **Reactive primitives**: `signal()`, `computed()`, `batch()` — lightweight, framework-agnostic, fine-grained change propagation per RFC-001
- **Typed EventBus**: `on`/`once`/`emit` with full TypeScript inference for plugin communication per RFC-002
- **Plugin system**: topological dependency resolution, lifecycle management (init/destroy in reverse), `expose()`/`getPlugin()` API, cell decorators
- **IndexMap**: view↔data index mapping for sort/filter without mutating source data
- **`createGrid()` API**: copy-on-init data isolation, reactive sort/filter state, batch updates, destroyed lifecycle guard

## Test plan

- [x] 92 unit tests across 6 test files (signal, events, plugin, index-map, grid, exports)
- [x] Coverage: 96.45% statements, 88.11% branches, 100% functions, 98.83% lines
- [x] Build passes (`tsup` ESM + DTS)
- [x] Type-check passes (`tsc --noEmit`)
- [x] Lint passes (ESLint strict + import ordering)
- [x] Format passes (Prettier)
- [x] Changeset included (`@gridsmith/core` minor)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)