### PR TITLE
feat(core): add DOM renderer with row/column virtualization

### DIFF
--- a/.changeset/dom-renderer-virtualization.md
+++ b/.changeset/dom-renderer-virtualization.md
@@ -1,0 +1,13 @@
+---
+'@gridsmith/core': minor
+---
+
+Add DOM renderer with row/column virtualization
+
+- `createRenderer()` mounts a virtualized grid into a container element
+- Row virtualization with fixed height for O(1) position calculation
+- Column virtualization with binary search for variable-width columns
+- Overscan buffer for smooth scrolling
+- ResizeObserver for container resize handling
+- Row element pooling to minimize GC pressure
+- Reactive: auto-updates on data, sort, filter, and column changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,7 @@
     "lint": "eslint src/"
   },
   "devDependencies": {
+    "jsdom": "^29.0.2",
     "tsup": "^8.3.0",
     "typescript": "^5.6.0",
     "vitest": "^4.1.0"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,17 @@ export const VERSION = '0.0.0';
 
 // Core API
 export { createGrid } from './grid';
+export { createRenderer } from './renderer';
+export type { RendererOptions, RendererInstance } from './renderer';
+
+// Virtualization
+export {
+  computeColumnLayout,
+  calculateVisibleRange,
+  getTotalHeight,
+  DEFAULT_CONFIG,
+} from './virtualization';
+export type { VirtualizationConfig, ColumnLayout } from './virtualization';
 
 // Reactive primitives
 export { signal, computed, batch } from './signal';

--- a/packages/core/src/renderer.spec.ts
+++ b/packages/core/src/renderer.spec.ts
@@ -1,0 +1,327 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import { createGrid } from './grid';
+import { createRenderer, type RendererInstance } from './renderer';
+import type { ColumnDef, Row } from './types';
+
+// ─── Helpers ──────────────────────────────────────────────
+
+const columns: ColumnDef[] = [
+  { id: 'name', header: 'Name', width: 120 },
+  { id: 'age', header: 'Age', width: 80 },
+  { id: 'city', header: 'City', width: 100 },
+];
+
+function makeRows(count: number): Row[] {
+  return Array.from({ length: count }, (_, i) => ({
+    name: `User ${i}`,
+    age: 20 + (i % 50),
+    city: i % 2 === 0 ? 'Seoul' : 'Tokyo',
+  }));
+}
+
+// jsdom does not implement layout, so we mock clientWidth/clientHeight
+function mockLayout(el: HTMLElement, width: number, height: number) {
+  Object.defineProperty(el, 'clientWidth', { value: width, configurable: true });
+  Object.defineProperty(el, 'clientHeight', { value: height, configurable: true });
+}
+
+// Mock ResizeObserver since jsdom doesn't have it
+class MockResizeObserver {
+  callback: ResizeObserverCallback;
+  constructor(cb: ResizeObserverCallback) {
+    this.callback = cb;
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+// Mock requestAnimationFrame for synchronous testing
+let pendingRAFCallbacks: FrameRequestCallback[] = [];
+
+function mockRAF() {
+  let id = 0;
+
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    pendingRAFCallbacks.push(cb);
+    return ++id;
+  });
+
+  vi.stubGlobal('cancelAnimationFrame', () => {
+    // simplified: just clear all pending
+  });
+}
+
+/** Flush all pending requestAnimationFrame callbacks */
+function flushRAF() {
+  const cbs = [...pendingRAFCallbacks];
+  pendingRAFCallbacks = [];
+  for (const cb of cbs) cb(performance.now());
+}
+
+// ─── Tests ────────────────────────────────────────────────
+
+describe('createRenderer', () => {
+  let container: HTMLDivElement;
+  let renderer: RendererInstance;
+
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
+    mockRAF();
+
+    container = document.createElement('div');
+    mockLayout(container, 400, 300);
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    renderer?.destroy();
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('creates root DOM structure', () => {
+    const grid = createGrid({ data: makeRows(10), columns });
+    renderer = createRenderer({ container, grid });
+
+    const root = container.querySelector('.gs-grid');
+    expect(root).toBeTruthy();
+    expect(root!.querySelector('.gs-header')).toBeTruthy();
+    expect(root!.querySelector('.gs-viewport')).toBeTruthy();
+    expect(root!.querySelector('.gs-canvas')).toBeTruthy();
+  });
+
+  it('renders header cells for each visible column', () => {
+    const grid = createGrid({ data: makeRows(10), columns });
+    renderer = createRenderer({ container, grid });
+
+    const headerCells = container.querySelectorAll('.gs-header-cell');
+    expect(headerCells).toHaveLength(3);
+    expect(headerCells[0].textContent).toBe('Name');
+    expect(headerCells[1].textContent).toBe('Age');
+    expect(headerCells[2].textContent).toBe('City');
+  });
+
+  it('does not render header cells for hidden columns', () => {
+    const colsWithHidden: ColumnDef[] = [
+      ...columns,
+      { id: 'hidden', header: 'Hidden', visible: false },
+    ];
+    const grid = createGrid({ data: makeRows(10), columns: colsWithHidden });
+    renderer = createRenderer({ container, grid });
+
+    const headerCells = container.querySelectorAll('.gs-header-cell');
+    expect(headerCells).toHaveLength(3); // hidden column excluded
+  });
+
+  it('sets canvas height based on total rows', () => {
+    const grid = createGrid({ data: makeRows(100), columns });
+    renderer = createRenderer({ container, grid, rowHeight: 32 });
+
+    const canvas = container.querySelector('.gs-canvas') as HTMLElement;
+    expect(canvas.style.height).toBe('3200px'); // 100 * 32
+  });
+
+  it('renders only visible rows (not all data rows)', () => {
+    const grid = createGrid({ data: makeRows(10000), columns });
+    renderer = createRenderer({ container, grid, rowHeight: 32, overscan: 2 });
+
+    const rows = container.querySelectorAll('.gs-row');
+    // With 300px container - 32px header = 268px viewport
+    // Even with jsdom, should be far fewer than 10000
+    expect(rows.length).toBeLessThan(50);
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it('renders cell values correctly', () => {
+    const grid = createGrid({
+      data: [{ name: 'Alice', age: 30, city: 'Seoul' }],
+      columns,
+    });
+    renderer = createRenderer({ container, grid });
+
+    const cells = container.querySelectorAll('.gs-cell');
+    const texts = Array.from(cells).map((c) => c.textContent);
+    expect(texts).toContain('Alice');
+    expect(texts).toContain('30');
+    expect(texts).toContain('Seoul');
+  });
+
+  it('renders null/undefined as empty string', () => {
+    const grid = createGrid({
+      data: [{ name: null, age: undefined, city: 'Seoul' }],
+      columns,
+    });
+    renderer = createRenderer({ container, grid });
+
+    const cells = container.querySelectorAll('.gs-cell');
+    expect(cells[0].textContent).toBe('');
+    expect(cells[1].textContent).toBe('');
+  });
+
+  it('updates when grid data changes', () => {
+    const grid = createGrid({ data: makeRows(5), columns });
+    renderer = createRenderer({ container, grid });
+
+    let cells = container.querySelectorAll('.gs-cell');
+    expect(cells[0].textContent).toBe('User 0');
+
+    grid.setCell(0, 'name', 'Updated');
+    flushRAF();
+
+    cells = container.querySelectorAll('.gs-cell');
+    const texts = Array.from(cells).map((c) => c.textContent);
+    expect(texts).toContain('Updated');
+  });
+
+  it('updates when columns change', () => {
+    const grid = createGrid({ data: makeRows(5), columns });
+    renderer = createRenderer({ container, grid });
+
+    grid.setColumns([{ id: 'name', header: 'Full Name', width: 200 }]);
+    flushRAF();
+
+    const headerCells = container.querySelectorAll('.gs-header-cell');
+    expect(headerCells).toHaveLength(1);
+    expect(headerCells[0].textContent).toBe('Full Name');
+  });
+
+  it('updates row count when data is replaced', () => {
+    const grid = createGrid({ data: makeRows(10), columns });
+    renderer = createRenderer({ container, grid, rowHeight: 32 });
+
+    grid.setData(makeRows(50));
+    flushRAF();
+
+    const canvas = container.querySelector('.gs-canvas') as HTMLElement;
+    expect(canvas.style.height).toBe('1600px'); // 50 * 32
+  });
+
+  it('refresh() forces a full re-render', () => {
+    const grid = createGrid({ data: makeRows(5), columns });
+    renderer = createRenderer({ container, grid });
+
+    const rowsBefore = container.querySelectorAll('.gs-row').length;
+    renderer.refresh();
+    const rowsAfter = container.querySelectorAll('.gs-row').length;
+
+    expect(rowsAfter).toBe(rowsBefore);
+  });
+
+  it('destroy() removes all DOM elements', () => {
+    const grid = createGrid({ data: makeRows(5), columns });
+    renderer = createRenderer({ container, grid });
+
+    expect(container.querySelector('.gs-grid')).toBeTruthy();
+
+    renderer.destroy();
+    renderer = undefined!;
+
+    expect(container.querySelector('.gs-grid')).toBeNull();
+  });
+
+  it('destroy() is idempotent', () => {
+    const grid = createGrid({ data: makeRows(5), columns });
+    renderer = createRenderer({ container, grid });
+
+    renderer.destroy();
+    // Second call should not throw
+    renderer.destroy();
+    renderer = undefined!;
+  });
+
+  it('applies cell decorations', () => {
+    const grid = createGrid({
+      data: [{ name: 'Alice', age: 30, city: 'Seoul' }],
+      columns,
+      plugins: [
+        {
+          name: 'test-decorator',
+          init(ctx) {
+            ctx.addCellDecorator(({ col }) => {
+              if (col === 'name') {
+                return { className: 'highlight', attributes: { 'data-test': 'yes' } };
+              }
+              return null;
+            });
+          },
+        },
+      ],
+    });
+    renderer = createRenderer({ container, grid });
+
+    const highlightedCells = container.querySelectorAll('.gs-cell.highlight');
+    expect(highlightedCells).toHaveLength(1);
+    expect(highlightedCells[0].getAttribute('data-test')).toBe('yes');
+  });
+
+  it('handles sort changes by re-rendering', () => {
+    const grid = createGrid({
+      data: [
+        { name: 'Bob', age: 25, city: 'Tokyo' },
+        { name: 'Alice', age: 30, city: 'Seoul' },
+      ],
+      columns: [
+        { id: 'name', header: 'Name', width: 120, sortable: true },
+        { id: 'age', header: 'Age', width: 80 },
+      ],
+    });
+    renderer = createRenderer({ container, grid });
+
+    grid.sortState.set([{ columnId: 'name', direction: 'asc' }]);
+    flushRAF();
+
+    const rows = container.querySelectorAll('.gs-row');
+    const firstRowCells = rows[0]?.querySelectorAll('.gs-cell');
+    expect(firstRowCells?.[0]?.textContent).toBe('Alice');
+  });
+
+  it('handles filter changes by updating canvas height', () => {
+    const grid = createGrid({
+      data: makeRows(100),
+      columns,
+    });
+    renderer = createRenderer({ container, grid, rowHeight: 32 });
+
+    const canvasBefore = container.querySelector('.gs-canvas') as HTMLElement;
+    expect(canvasBefore.style.height).toBe('3200px');
+
+    grid.filterState.set([{ columnId: 'city', operator: 'eq', value: 'Seoul' }]);
+    flushRAF();
+
+    const canvasAfter = container.querySelector('.gs-canvas') as HTMLElement;
+    // ~50 rows match (even indices)
+    const height = parseInt(canvasAfter.style.height, 10);
+    expect(height).toBeLessThan(3200);
+    expect(height).toBeGreaterThan(0);
+  });
+
+  it('handles empty data (0 rows)', () => {
+    const grid = createGrid({ data: [], columns });
+    renderer = createRenderer({ container, grid });
+
+    const rows = container.querySelectorAll('.gs-row');
+    expect(rows).toHaveLength(0);
+
+    const canvas = container.querySelector('.gs-canvas') as HTMLElement;
+    expect(canvas.style.height).toBe('0px');
+  });
+
+  it('respects custom rowHeight', () => {
+    const grid = createGrid({ data: makeRows(10), columns });
+    renderer = createRenderer({ container, grid, rowHeight: 48 });
+
+    const canvas = container.querySelector('.gs-canvas') as HTMLElement;
+    expect(canvas.style.height).toBe('480px'); // 10 * 48
+  });
+
+  it('respects custom headerHeight', () => {
+    const grid = createGrid({ data: makeRows(10), columns });
+    renderer = createRenderer({ container, grid, headerHeight: 40 });
+
+    const header = container.querySelector('.gs-header') as HTMLElement;
+    expect(header.style.height).toBe('40px');
+  });
+});

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1,0 +1,377 @@
+import type { Unsubscribe } from './signal';
+import type { GridInstance, ColumnDef, VisibleRange } from './types';
+import {
+  computeColumnLayout,
+  calculateVisibleRange,
+  getTotalHeight,
+  DEFAULT_CONFIG,
+  type VirtualizationConfig,
+  type ColumnLayout,
+} from './virtualization';
+
+// ─── Renderer Options ─────────────────────────────────────
+
+export interface RendererOptions {
+  /** Container element to mount the grid into */
+  container: HTMLElement;
+  /** Grid instance to render */
+  grid: GridInstance;
+  /** Fixed row height in pixels (default: 32) */
+  rowHeight?: number;
+  /** Header row height in pixels (default: rowHeight) */
+  headerHeight?: number;
+  /** Number of extra rows/cols to render outside viewport (default: 3) */
+  overscan?: number;
+  /** Default column width in pixels (default: 100) */
+  defaultColumnWidth?: number;
+}
+
+export interface RendererInstance {
+  /** Force a full re-render */
+  refresh(): void;
+  /** Clean up and remove all DOM elements */
+  destroy(): void;
+}
+
+// ─── CSS Class Names ──────────────────────────────────────
+
+const CLS = {
+  root: 'gs-grid',
+  header: 'gs-header',
+  headerCell: 'gs-header-cell',
+  viewport: 'gs-viewport',
+  canvas: 'gs-canvas',
+  row: 'gs-row',
+  cell: 'gs-cell',
+} as const;
+
+// ─── Renderer Implementation ──────────────────────────────
+
+export function createRenderer(options: RendererOptions): RendererInstance {
+  const { container, grid } = options;
+
+  const config: VirtualizationConfig = {
+    rowHeight: options.rowHeight ?? DEFAULT_CONFIG.rowHeight,
+    overscan: options.overscan ?? DEFAULT_CONFIG.overscan,
+    defaultColumnWidth: options.defaultColumnWidth ?? DEFAULT_CONFIG.defaultColumnWidth,
+  };
+
+  const headerHeight = options.headerHeight ?? config.rowHeight;
+
+  // ─── DOM Structure ────────────────────────────────────
+  // <div.gs-grid>
+  //   <div.gs-header>
+  //     <div.gs-header-cell /> ...
+  //   </div>
+  //   <div.gs-viewport>          ← scroll container
+  //     <div.gs-canvas>          ← total size spacer
+  //       <div.gs-row>           ← absolutely positioned
+  //         <div.gs-cell /> ...
+  //       </div> ...
+  //     </div>
+  //   </div>
+  // </div>
+
+  const root = el('div', CLS.root);
+  const header = el('div', CLS.header);
+  const viewport = el('div', CLS.viewport);
+  const canvas = el('div', CLS.canvas);
+
+  root.style.cssText = 'position:relative;overflow:hidden;';
+  header.style.cssText = `position:relative;height:${headerHeight}px;overflow:hidden;display:flex;`;
+  viewport.style.cssText = 'position:relative;overflow:auto;will-change:transform;';
+  canvas.style.cssText = 'position:relative;';
+
+  viewport.appendChild(canvas);
+  root.appendChild(header);
+  root.appendChild(viewport);
+  container.appendChild(root);
+
+  // ─── State ────────────────────────────────────────────
+
+  let columnLayout: ColumnLayout = computeColumnLayout(
+    grid.columns.get(),
+    config.defaultColumnWidth,
+  );
+  let prevRange: VisibleRange | null = null;
+  let rafId: number | null = null;
+  let destroyed = false;
+
+  // Row element pool: reuse DOM nodes to minimize GC
+  const rowPool: HTMLDivElement[] = [];
+  // Currently rendered rows: viewIndex → element
+  const activeRows = new Map<number, HTMLDivElement>();
+
+  // ─── Sizing ───────────────────────────────────────────
+
+  function updateSizing() {
+    const totalHeight = getTotalHeight(grid.rowCount, config.rowHeight);
+    canvas.style.height = `${totalHeight}px`;
+    canvas.style.width = `${columnLayout.totalWidth}px`;
+    header.style.width = `${columnLayout.totalWidth}px`;
+
+    // Viewport height = container height minus header
+    const containerHeight = container.clientHeight;
+    viewport.style.height = `${containerHeight - headerHeight}px`;
+  }
+
+  // ─── Header Rendering ────────────────────────────────
+
+  function renderHeader() {
+    header.innerHTML = '';
+    const columns = grid.columns.get();
+    for (let c = 0; c < columns.length; c++) {
+      const col = columns[c];
+      if (col.visible === false) continue;
+      const cell = el('div', CLS.headerCell);
+      cell.textContent = col.header;
+      cell.style.cssText = `position:absolute;left:${columnLayout.offsets[c]}px;width:${columnLayout.widths[c]}px;height:${headerHeight}px;box-sizing:border-box;overflow:hidden;`;
+      header.appendChild(cell);
+    }
+  }
+
+  // ─── Cell Rendering ───────────────────────────────────
+
+  function renderRow(viewIndex: number, columns: ColumnDef[], range: VisibleRange): HTMLDivElement {
+    const row = acquireRow();
+    row.innerHTML = '';
+    row.style.cssText = `position:absolute;top:${viewIndex * config.rowHeight}px;left:0;width:${columnLayout.totalWidth}px;height:${config.rowHeight}px;`;
+    row.dataset.viewIndex = String(viewIndex);
+
+    for (let c = range.colStart; c <= range.colEnd; c++) {
+      const col = columns[c];
+      if (col.visible === false) continue;
+
+      const cell = el('div', CLS.cell);
+      const value = grid.getCell(viewIndex, col.id);
+      cell.textContent = formatCellValue(value);
+      cell.style.cssText = `position:absolute;left:${columnLayout.offsets[c]}px;width:${columnLayout.widths[c]}px;height:${config.rowHeight}px;box-sizing:border-box;overflow:hidden;`;
+
+      // Apply cell decorations
+      const decorations = grid.getCellDecorations(viewIndex, col.id);
+      for (const dec of decorations) {
+        if (dec.className) cell.classList.add(...dec.className.split(' '));
+        if (dec.style) Object.assign(cell.style, dec.style);
+        if (dec.attributes) {
+          for (const [k, v] of Object.entries(dec.attributes)) {
+            cell.setAttribute(k, v);
+          }
+        }
+      }
+
+      row.appendChild(cell);
+    }
+
+    return row;
+  }
+
+  function acquireRow(): HTMLDivElement {
+    return rowPool.pop() ?? document.createElement('div');
+  }
+
+  function releaseRow(row: HTMLDivElement) {
+    row.innerHTML = '';
+    rowPool.push(row);
+  }
+
+  // ─── Render Loop ──────────────────────────────────────
+
+  function render() {
+    if (destroyed) return;
+
+    // Always refresh sizing before computing visible range
+    // (handles filter/data changes that alter row count)
+    updateSizing();
+
+    const totalRows = grid.rowCount;
+    const viewportWidth = viewport.clientWidth;
+    const viewportHeight = viewport.clientHeight;
+    const scrollTop = viewport.scrollTop;
+    const scrollLeft = viewport.scrollLeft;
+
+    if (totalRows === 0) {
+      clearAllRows();
+      prevRange = null;
+      return;
+    }
+
+    const range = calculateVisibleRange(
+      scrollTop,
+      scrollLeft,
+      viewportWidth,
+      viewportHeight,
+      totalRows,
+      columnLayout,
+      config,
+    );
+
+    // Sync header scroll
+    header.scrollLeft = scrollLeft;
+
+    const columns = grid.columns.get();
+
+    // Check if we need to re-render columns (horizontal scroll changed)
+    const colsChanged =
+      !prevRange || range.colStart !== prevRange.colStart || range.colEnd !== prevRange.colEnd;
+
+    // Remove rows that are no longer visible
+    for (const [viewIndex, row] of activeRows) {
+      if (viewIndex < range.rowStart || viewIndex > range.rowEnd) {
+        canvas.removeChild(row);
+        releaseRow(row);
+        activeRows.delete(viewIndex);
+      }
+    }
+
+    // Add or update visible rows
+    for (let r = range.rowStart; r <= range.rowEnd; r++) {
+      const existing = activeRows.get(r);
+      if (existing && !colsChanged) {
+        // Row already rendered and columns haven't changed
+        continue;
+      }
+
+      if (existing) {
+        canvas.removeChild(existing);
+        releaseRow(existing);
+      }
+
+      const row = renderRow(r, columns, range);
+      row.className = CLS.row;
+      canvas.appendChild(row);
+      activeRows.set(r, row);
+    }
+
+    prevRange = range;
+  }
+
+  function clearAllRows() {
+    for (const [, row] of activeRows) {
+      canvas.removeChild(row);
+      releaseRow(row);
+    }
+    activeRows.clear();
+  }
+
+  function scheduleRender() {
+    if (rafId !== null) return;
+    rafId = requestAnimationFrame(() => {
+      rafId = null;
+      render();
+    });
+  }
+
+  // ─── Event Listeners ─────────────────────────────────
+
+  function onScroll() {
+    scheduleRender();
+  }
+
+  viewport.addEventListener('scroll', onScroll, { passive: true });
+
+  // ResizeObserver for container resize
+  const resizeObserver = new ResizeObserver(() => {
+    updateSizing();
+    scheduleRender();
+  });
+  resizeObserver.observe(container);
+
+  // Subscribe to grid state changes
+  const unsubs: Unsubscribe[] = [];
+
+  unsubs.push(
+    grid.subscribe('data:rowsUpdate', () => {
+      clearAllRows();
+      prevRange = null;
+      scheduleRender();
+    }),
+  );
+
+  unsubs.push(
+    grid.subscribe('data:change', () => {
+      clearAllRows();
+      prevRange = null;
+      scheduleRender();
+    }),
+  );
+
+  unsubs.push(
+    grid.subscribe('columns:update', () => {
+      columnLayout = computeColumnLayout(grid.columns.get(), config.defaultColumnWidth);
+      renderHeader();
+      clearAllRows();
+      prevRange = null;
+      scheduleRender();
+    }),
+  );
+
+  unsubs.push(
+    grid.subscribe('sort:change', () => {
+      clearAllRows();
+      prevRange = null;
+      scheduleRender();
+    }),
+  );
+
+  unsubs.push(
+    grid.subscribe('filter:change', () => {
+      clearAllRows();
+      prevRange = null;
+      scheduleRender();
+    }),
+  );
+
+  // ─── Initial Render ───────────────────────────────────
+
+  updateSizing();
+  renderHeader();
+  render();
+
+  // ─── Public API ───────────────────────────────────────
+
+  return {
+    refresh() {
+      columnLayout = computeColumnLayout(grid.columns.get(), config.defaultColumnWidth);
+      renderHeader();
+      updateSizing();
+      clearAllRows();
+      prevRange = null;
+      render();
+    },
+
+    destroy() {
+      if (destroyed) return;
+      destroyed = true;
+
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+
+      viewport.removeEventListener('scroll', onScroll);
+      resizeObserver.disconnect();
+
+      for (const unsub of unsubs) unsub();
+      unsubs.length = 0;
+
+      clearAllRows();
+      rowPool.length = 0;
+
+      container.removeChild(root);
+    },
+  };
+}
+
+// ─── Helpers ──────────────────────────────────────────────
+
+function el(tag: string, className: string): HTMLDivElement {
+  const element = document.createElement(tag) as HTMLDivElement;
+  element.className = className;
+  return element;
+}
+
+function formatCellValue(value: string | number | boolean | Date | null | undefined): string {
+  if (value == null) return '';
+  if (value instanceof Date) return value.toLocaleDateString();
+  return String(value);
+}

--- a/packages/core/src/virtualization.spec.ts
+++ b/packages/core/src/virtualization.spec.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ColumnDef } from './types';
+import {
+  computeColumnLayout,
+  calculateVisibleRange,
+  getTotalHeight,
+  DEFAULT_CONFIG,
+} from './virtualization';
+
+// ─── computeColumnLayout ──────────────────────────────────
+
+describe('computeColumnLayout', () => {
+  it('uses default width when column width is not set', () => {
+    const cols: ColumnDef[] = [
+      { id: 'a', header: 'A' },
+      { id: 'b', header: 'B' },
+    ];
+    const layout = computeColumnLayout(cols, 100);
+
+    expect(layout.widths).toEqual([100, 100]);
+    expect(layout.offsets).toEqual([0, 100]);
+    expect(layout.totalWidth).toBe(200);
+  });
+
+  it('uses column.width when set', () => {
+    const cols: ColumnDef[] = [
+      { id: 'a', header: 'A', width: 50 },
+      { id: 'b', header: 'B', width: 200 },
+      { id: 'c', header: 'C', width: 80 },
+    ];
+    const layout = computeColumnLayout(cols, 100);
+
+    expect(layout.widths).toEqual([50, 200, 80]);
+    expect(layout.offsets).toEqual([0, 50, 250]);
+    expect(layout.totalWidth).toBe(330);
+  });
+
+  it('sets width to 0 for hidden columns', () => {
+    const cols: ColumnDef[] = [
+      { id: 'a', header: 'A', width: 100 },
+      { id: 'b', header: 'B', width: 100, visible: false },
+      { id: 'c', header: 'C', width: 100 },
+    ];
+    const layout = computeColumnLayout(cols, 100);
+
+    expect(layout.widths).toEqual([100, 0, 100]);
+    expect(layout.offsets).toEqual([0, 100, 100]);
+    expect(layout.totalWidth).toBe(200);
+  });
+
+  it('handles empty column list', () => {
+    const layout = computeColumnLayout([], 100);
+
+    expect(layout.widths).toEqual([]);
+    expect(layout.offsets).toEqual([]);
+    expect(layout.totalWidth).toBe(0);
+  });
+});
+
+// ─── calculateVisibleRange ────────────────────────────────
+
+describe('calculateVisibleRange', () => {
+  const cols: ColumnDef[] = [
+    { id: 'a', header: 'A', width: 100 },
+    { id: 'b', header: 'B', width: 100 },
+    { id: 'c', header: 'C', width: 100 },
+    { id: 'd', header: 'D', width: 100 },
+    { id: 'e', header: 'E', width: 100 },
+  ];
+  const layout = computeColumnLayout(cols, 100);
+  const config = { ...DEFAULT_CONFIG, overscan: 1 };
+
+  it('computes visible rows at scroll top 0', () => {
+    const range = calculateVisibleRange(0, 0, 300, 100, 1000, layout, config);
+
+    // viewport 100px / rowHeight 32 = ceil(3.125) = 4 visible rows
+    // with overscan 1: rowStart = max(0, 0-1) = 0, rowEnd = min(999, 0+4+1) = 5
+    expect(range.rowStart).toBe(0);
+    expect(range.rowEnd).toBe(5);
+  });
+
+  it('computes visible rows when scrolled down', () => {
+    const range = calculateVisibleRange(320, 0, 300, 100, 1000, layout, config);
+
+    // scrollTop 320 / 32 = row 10
+    // rowStart = max(0, 10-1) = 9
+    // rowEnd = min(999, 10+4+1) = 15
+    expect(range.rowStart).toBe(9);
+    expect(range.rowEnd).toBe(15);
+  });
+
+  it('clamps rowEnd to totalRows - 1', () => {
+    const range = calculateVisibleRange(0, 0, 300, 500, 5, layout, config);
+
+    expect(range.rowStart).toBe(0);
+    expect(range.rowEnd).toBe(4); // max index for 5 rows
+  });
+
+  it('computes visible columns at scroll left 0', () => {
+    const range = calculateVisibleRange(0, 0, 250, 100, 100, layout, config);
+
+    // viewport 250px shows columns 0,1,2 (300px total)
+    // with overscan 1: colStart = 0, colEnd = min(4, 2+1) = 3
+    expect(range.colStart).toBe(0);
+    expect(range.colEnd).toBe(3);
+  });
+
+  it('computes visible columns when scrolled right', () => {
+    const range = calculateVisibleRange(0, 200, 150, 100, 100, layout, config);
+
+    // scrollLeft 200 → column 2 starts at 200
+    // viewport 150px shows columns 2,3 (200-350)
+    // overscan 1: colStart = max(0, 2-1) = 1, colEnd = min(4, 3+1) = 4
+    expect(range.colStart).toBe(1);
+    expect(range.colEnd).toBe(4);
+  });
+
+  it('handles 1M rows efficiently', () => {
+    const totalRows = 1_000_000;
+    const start = performance.now();
+    const range = calculateVisibleRange(500_000 * 32, 0, 500, 600, totalRows, layout, config);
+    const elapsed = performance.now() - start;
+
+    expect(elapsed).toBeLessThan(5); // O(1) for rows
+    expect(range.rowStart).toBe(500_000 - config.overscan);
+    expect(range.rowEnd).toBeLessThan(totalRows);
+  });
+
+  it('handles many columns with binary search', () => {
+    const manyCols: ColumnDef[] = Array.from({ length: 200 }, (_, i) => ({
+      id: `col${i}`,
+      header: `Col ${i}`,
+      width: 80,
+    }));
+    const manyLayout = computeColumnLayout(manyCols, 80);
+
+    const range = calculateVisibleRange(0, 8000, 800, 600, 100, manyLayout, config);
+
+    // scrollLeft 8000 / 80 = column 100
+    expect(range.colStart).toBeGreaterThanOrEqual(99);
+    expect(range.colEnd).toBeLessThanOrEqual(111);
+  });
+
+  it('returns empty range when totalRows is 0', () => {
+    const range = calculateVisibleRange(0, 0, 300, 100, 0, layout, config);
+
+    expect(range.rowStart).toBe(0);
+    expect(range.rowEnd).toBe(-1);
+    expect(range.colStart).toBe(0);
+    expect(range.colEnd).toBe(-1);
+  });
+
+  it('returns empty range when columns are empty', () => {
+    const emptyLayout = computeColumnLayout([], 100);
+    const range = calculateVisibleRange(0, 0, 300, 100, 100, emptyLayout, config);
+
+    expect(range.rowStart).toBe(0);
+    expect(range.rowEnd).toBe(-1);
+  });
+
+  it('skips hidden columns at boundaries', () => {
+    const colsWithHidden: ColumnDef[] = [
+      { id: 'a', header: 'A', width: 100, visible: false },
+      { id: 'b', header: 'B', width: 100 },
+      { id: 'c', header: 'C', width: 100 },
+    ];
+    const hiddenLayout = computeColumnLayout(colsWithHidden, 100);
+    const range = calculateVisibleRange(0, 0, 200, 100, 10, hiddenLayout, {
+      ...DEFAULT_CONFIG,
+      overscan: 0,
+    });
+
+    expect(range.colStart).toBe(1); // skip hidden col 0
+  });
+});
+
+// ─── getTotalHeight ───────────────────────────────────────
+
+describe('getTotalHeight', () => {
+  it('returns rows * rowHeight', () => {
+    expect(getTotalHeight(100, 32)).toBe(3200);
+    expect(getTotalHeight(1_000_000, 32)).toBe(32_000_000);
+  });
+
+  it('returns 0 for empty grid', () => {
+    expect(getTotalHeight(0, 32)).toBe(0);
+  });
+});

--- a/packages/core/src/virtualization.ts
+++ b/packages/core/src/virtualization.ts
@@ -1,0 +1,116 @@
+import type { VisibleRange, ColumnDef } from './types';
+
+// ─── Virtualization Config ────────────────────────────────
+
+export interface VirtualizationConfig {
+  /** Fixed row height in pixels */
+  rowHeight: number;
+  /** Number of extra rows/columns to render outside viewport */
+  overscan: number;
+  /** Default column width when ColumnDef.width is not set */
+  defaultColumnWidth: number;
+}
+
+export const DEFAULT_CONFIG: VirtualizationConfig = {
+  rowHeight: 32,
+  overscan: 3,
+  defaultColumnWidth: 100,
+};
+
+// ─── Column Layout ────────────────────────────────────────
+
+export interface ColumnLayout {
+  /** Left offset of each column in pixels */
+  offsets: number[];
+  /** Resolved width of each column in pixels */
+  widths: number[];
+  /** Total width of all columns */
+  totalWidth: number;
+}
+
+export function computeColumnLayout(columns: ColumnDef[], defaultWidth: number): ColumnLayout {
+  const widths: number[] = [];
+  const offsets: number[] = [];
+  let offset = 0;
+
+  for (const col of columns) {
+    const w = col.visible === false ? 0 : (col.width ?? defaultWidth);
+    offsets.push(offset);
+    widths.push(w);
+    offset += w;
+  }
+
+  return { offsets, widths, totalWidth: offset };
+}
+
+// ─── Visible Range Calculation ────────────────────────────
+
+export function calculateVisibleRange(
+  scrollTop: number,
+  scrollLeft: number,
+  viewportWidth: number,
+  viewportHeight: number,
+  totalRows: number,
+  columnLayout: ColumnLayout,
+  config: VirtualizationConfig,
+): VisibleRange {
+  const { rowHeight, overscan } = config;
+  const totalCols = columnLayout.offsets.length;
+
+  // Empty grid → empty range
+  if (totalRows === 0 || totalCols === 0) {
+    return { rowStart: 0, rowEnd: -1, colStart: 0, colEnd: -1 };
+  }
+
+  // ─── Rows (fixed height → O(1)) ────────────────────────
+  const rawRowStart = Math.floor(scrollTop / rowHeight);
+  const visibleRowCount = Math.ceil(viewportHeight / rowHeight);
+  const rowStart = Math.max(0, rawRowStart - overscan);
+  const rowEnd = Math.min(totalRows - 1, rawRowStart + visibleRowCount + overscan);
+
+  // ─── Columns (variable width → binary search) ──────────
+  const { offsets, widths } = columnLayout;
+
+  let colStart = binarySearchOffset(offsets, scrollLeft);
+  colStart = Math.max(0, colStart - overscan);
+
+  const scrollRight = scrollLeft + viewportWidth;
+  let colEnd = binarySearchOffset(offsets, scrollRight);
+  // Ensure we include the column that contains scrollRight
+  if (colEnd < totalCols - 1 && offsets[colEnd] + widths[colEnd] < scrollRight) {
+    colEnd++;
+  }
+  colEnd = Math.min(totalCols - 1, colEnd + overscan);
+
+  // Skip hidden columns at boundaries
+  while (colStart < colEnd && widths[colStart] === 0) colStart++;
+  while (colEnd > colStart && widths[colEnd] === 0) colEnd--;
+
+  return { rowStart, rowEnd, colStart, colEnd };
+}
+
+/**
+ * Binary search for the index of the column whose offset is <= target.
+ * Returns the index of the last column whose left edge is at or before `target`.
+ */
+function binarySearchOffset(offsets: number[], target: number): number {
+  let lo = 0;
+  let hi = offsets.length - 1;
+
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >>> 1;
+    if (offsets[mid] <= target) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+
+  return lo;
+}
+
+// ─── Total Content Height ─────────────────────────────────
+
+export function getTotalHeight(totalRows: number, rowHeight: number): number {
+  return totalRows * rowHeight;
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "compilerOptions": { "outDir": "dist", "rootDir": "src", "lib": ["ES2022", "DOM"] },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,7 +62,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3))
+        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3))
 
   apps/docs:
     devDependencies:
@@ -146,6 +146,9 @@ importers:
 
   packages/core:
     devDependencies:
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2
       tsup:
         specifier: ^8.3.0
         version: 8.5.1(postcss@8.5.9)(typescript@5.9.3)(yaml@2.8.3)
@@ -154,7 +157,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3))
+        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3))
 
   packages/react:
     dependencies:
@@ -182,7 +185,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3))
+        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3))
 
   packages/ui:
     dependencies:
@@ -213,7 +216,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3))
+        version: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3))
 
 packages:
 
@@ -292,6 +295,17 @@ packages:
   '@algolia/requester-node-http@5.50.1':
     resolution: {integrity: sha512-qmo1LXrNKLHvJE6mdQbLnsZAoZvj7VyF2ft4xmbSGWI2WWm87fx/CjUX4kEExt4y0a6T6nEts6ofpUfH5TEE1A==}
     engines: {node: '>= 14.0.0'}
+
+  '@asamuzakjp/css-color@5.1.10':
+    resolution: {integrity: sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.0.9':
+    resolution: {integrity: sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -384,6 +398,10 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@changesets/apply-release-plan@7.1.0':
     resolution: {integrity: sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ==}
 
@@ -444,6 +462,42 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.0':
+    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@docsearch/css@3.8.2':
     resolution: {integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==}
@@ -965,6 +1019,15 @@ packages:
   '@eslint/plugin-kit@0.7.1':
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1759,6 +1822,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
 
@@ -1870,8 +1936,16 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
@@ -1884,6 +1958,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1923,6 +2000,10 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
@@ -2172,6 +2253,10 @@ packages:
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -2227,6 +2312,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
@@ -2271,6 +2359,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.0.2:
+    resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2406,6 +2503,10 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2424,6 +2525,9 @@ packages:
 
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2551,6 +2655,9 @@ packages:
 
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
+
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2696,6 +2803,10 @@ packages:
     resolution: {integrity: sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==}
     hasBin: true
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -2729,6 +2840,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2850,6 +2965,9 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
@@ -2882,12 +3000,27 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.28:
+    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@7.0.28:
+    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -2952,6 +3085,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -3165,8 +3302,24 @@ packages:
       typescript:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -3188,6 +3341,13 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -3318,6 +3478,22 @@ snapshots:
     dependencies:
       '@algolia/client-common': 5.50.1
 
+  '@asamuzakjp/css-color@5.1.10':
+    dependencies:
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.0.9':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -3433,6 +3609,10 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
 
   '@changesets/apply-release-plan@7.1.0':
     dependencies:
@@ -3591,6 +3771,30 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.3
       prettier: 2.8.8
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@docsearch/css@3.8.2': {}
 
@@ -3890,6 +4094,8 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.0': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -4427,7 +4633,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -4638,6 +4844,10 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   birpc@2.9.0: {}
 
   brace-expansion@5.0.5:
@@ -4728,13 +4938,27 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   dataloader@1.4.0: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -4764,6 +4988,8 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  entities@6.0.1: {}
 
   entities@7.0.1: {}
 
@@ -5112,6 +5338,12 @@ snapshots:
 
   hookable@5.5.3: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@2.0.2: {}
 
   html-void-elements@3.0.0: {}
@@ -5147,6 +5379,8 @@ snapshots:
       is-extglob: 2.1.1
 
   is-number@7.0.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-subdir@1.2.0:
     dependencies:
@@ -5185,6 +5419,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.0.2:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.10
+      '@asamuzakjp/dom-selector': 7.0.9
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.5
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -5300,6 +5560,8 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
+  lru-cache@11.3.5: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -5331,6 +5593,8 @@ snapshots:
       unist-util-position: 5.0.0
       unist-util-visit: 5.1.0
       vfile: 6.0.3
+
+  mdn-data@2.27.1: {}
 
   merge2@1.4.1: {}
 
@@ -5448,6 +5712,10 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -5547,6 +5815,8 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
+  require-from-string@2.0.2: {}
+
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -5617,6 +5887,10 @@ snapshots:
       queue-microtask: 1.2.3
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -5728,6 +6002,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  symbol-tree@3.2.4: {}
+
   tabbable@6.4.0: {}
 
   term-size@2.2.1: {}
@@ -5753,11 +6029,25 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.0.28: {}
+
+  tldts@7.0.28:
+    dependencies:
+      tldts-core: 7.0.28
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.28
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -5829,6 +6119,8 @@ snapshots:
   ufo@1.6.3: {}
 
   undici-types@6.21.0: {}
+
+  undici@7.25.0: {}
 
   unist-util-is@6.0.1:
     dependencies:
@@ -5985,7 +6277,7 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3)):
+  vitest@4.1.4(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(yaml@2.8.3))
@@ -6010,6 +6302,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.17
       '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
+      jsdom: 29.0.2
     transitivePeerDependencies:
       - msw
 
@@ -6023,7 +6316,23 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -6046,6 +6355,10 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
## Summary

- Add `createRenderer()` that mounts a virtualized grid into a container element with row/column virtualization
- Row virtualization uses fixed-height O(1) lookup; column virtualization uses binary search for variable widths
- Includes row element pooling, ResizeObserver, overscan buffer, and reactive updates on grid state changes (data, sort, filter, columns)

Closes #3

## Test plan

- [x] 127 tests passing (16 virtualization + 19 renderer + existing 92)
- [x] Coverage: 94.3% statements, 81.9% branches, 97.8% functions
- [x] Build, type-check, lint all pass
- [x] Changeset included (`@gridsmith/core` minor)
- [ ] Manual verification with playground (1M rows, 100+ columns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)