### PR TITLE
feat: basic cell editing (text/number/select/checkbox/date)

### DIFF
--- a/.changeset/basic-cell-editing.md
+++ b/.changeset/basic-cell-editing.md
@@ -1,0 +1,6 @@
+---
+'@gridsmith/core': minor
+'@gridsmith/react': minor
+---
+
+Add basic cell editing: text/number/select/checkbox/date editors, `defineEditor` custom editor API, double-click/F2/type-to-edit, Enter/Esc/Tab behavior, and `editable` column flag for read-only cells

--- a/packages/core/src/editing.spec.ts
+++ b/packages/core/src/editing.spec.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createEditingPlugin } from './editing';
+import { createGrid } from './grid';
+import type { ColumnDef, EditingPluginApi, Row } from './types';
+
+const columns: ColumnDef[] = [
+  { id: 'name', header: 'Name', type: 'text' },
+  { id: 'age', header: 'Age', type: 'number' },
+  { id: 'active', header: 'Active', type: 'checkbox' },
+  {
+    id: 'city',
+    header: 'City',
+    type: 'select',
+    selectOptions: [
+      { label: 'Seoul', value: 'Seoul' },
+      { label: 'Tokyo', value: 'Tokyo' },
+    ],
+  },
+  { id: 'joined', header: 'Joined', type: 'date' },
+  { id: 'readonly', header: 'ReadOnly', type: 'text', editable: false },
+];
+
+const data: Row[] = [
+  {
+    name: 'Alice',
+    age: 30,
+    active: true,
+    city: 'Seoul',
+    joined: new Date('2024-01-15'),
+    readonly: 'fixed',
+  },
+  {
+    name: 'Bob',
+    age: 25,
+    active: false,
+    city: 'Tokyo',
+    joined: new Date('2023-06-01'),
+    readonly: 'fixed',
+  },
+];
+
+function setup() {
+  const editingPlugin = createEditingPlugin();
+  const grid = createGrid({ data, columns, plugins: [editingPlugin] });
+  const api = grid.getPlugin<EditingPluginApi>('editing')!;
+  return { grid, api };
+}
+
+describe('editing plugin', () => {
+  describe('beginEdit', () => {
+    it('enters edit mode on an editable cell', () => {
+      const { api } = setup();
+      const result = api.beginEdit(0, 'name');
+      expect(result).toBe(true);
+      expect(api.isEditing()).toBe(true);
+
+      const state = api.getEditState();
+      expect(state).toEqual({
+        rowIndex: 0,
+        columnId: 'name',
+        value: 'Alice',
+        originalValue: 'Alice',
+      });
+    });
+
+    it('returns false for read-only columns', () => {
+      const { api } = setup();
+      const result = api.beginEdit(0, 'readonly');
+      expect(result).toBe(false);
+      expect(api.isEditing()).toBe(false);
+    });
+
+    it('supports type-to-edit with initialChar', () => {
+      const { api } = setup();
+      api.beginEdit(0, 'name', 'X');
+
+      const state = api.getEditState();
+      expect(state!.value).toBe('X');
+      expect(state!.originalValue).toBe('Alice');
+    });
+
+    it('auto-commits previous edit when starting a new one', () => {
+      const { grid, api } = setup();
+      api.beginEdit(0, 'name');
+      api.setValue('Changed');
+
+      api.beginEdit(1, 'name');
+      expect(grid.getCell(0, 'name')).toBe('Changed');
+      expect(api.getEditState()!.rowIndex).toBe(1);
+    });
+
+    it('emits edit:begin event', () => {
+      const { grid, api } = setup();
+      const handler = vi.fn();
+      grid.subscribe('edit:begin', handler);
+
+      api.beginEdit(0, 'name');
+      expect(handler).toHaveBeenCalledWith({
+        rowIndex: 0,
+        columnId: 'name',
+        value: 'Alice',
+        originalValue: 'Alice',
+      });
+    });
+  });
+
+  describe('commitEdit', () => {
+    it('commits value and exits edit mode', () => {
+      const { grid, api } = setup();
+      api.beginEdit(0, 'name');
+      api.setValue('Eve');
+      api.commitEdit();
+
+      expect(api.isEditing()).toBe(false);
+      expect(grid.getCell(0, 'name')).toBe('Eve');
+    });
+
+    it('parses number strings through the number editor', () => {
+      const { grid, api } = setup();
+      api.beginEdit(0, 'age');
+      api.setValue('42');
+      api.commitEdit();
+
+      expect(grid.getCell(0, 'age')).toBe(42);
+    });
+
+    it('parses empty number string as null', () => {
+      const { grid, api } = setup();
+      api.beginEdit(0, 'age');
+      api.setValue('');
+      api.commitEdit();
+
+      expect(grid.getCell(0, 'age')).toBeNull();
+    });
+
+    it('parses date strings through the date editor', () => {
+      const { grid, api } = setup();
+      api.beginEdit(0, 'joined');
+      api.setValue('2025-03-15');
+      api.commitEdit();
+
+      const cell = grid.getCell(0, 'joined');
+      expect(cell).toBeInstanceOf(Date);
+      expect((cell as Date).toISOString().slice(0, 10)).toBe('2025-03-15');
+    });
+
+    it('emits edit:commit and data:change events', () => {
+      const { grid, api } = setup();
+      const commitHandler = vi.fn();
+      const changeHandler = vi.fn();
+      grid.subscribe('edit:commit', commitHandler);
+      grid.subscribe('data:change', changeHandler);
+
+      api.beginEdit(0, 'name');
+      api.setValue('Eve');
+      api.commitEdit();
+
+      expect(commitHandler).toHaveBeenCalledWith({
+        rowIndex: 0,
+        columnId: 'name',
+        oldValue: 'Alice',
+        newValue: 'Eve',
+      });
+      expect(changeHandler).toHaveBeenCalled();
+    });
+
+    it('returns false when not editing', () => {
+      const { api } = setup();
+      expect(api.commitEdit()).toBe(false);
+    });
+  });
+
+  describe('cancelEdit', () => {
+    it('exits edit mode without changing data', () => {
+      const { grid, api } = setup();
+      api.beginEdit(0, 'name');
+      api.setValue('Changed');
+      api.cancelEdit();
+
+      expect(api.isEditing()).toBe(false);
+      expect(grid.getCell(0, 'name')).toBe('Alice');
+    });
+
+    it('emits edit:cancel event', () => {
+      const { grid, api } = setup();
+      const handler = vi.fn();
+      grid.subscribe('edit:cancel', handler);
+
+      api.beginEdit(0, 'name');
+      api.cancelEdit();
+
+      expect(handler).toHaveBeenCalledWith({ rowIndex: 0, columnId: 'name' });
+    });
+  });
+
+  describe('setValue', () => {
+    it('updates the edit value', () => {
+      const { api } = setup();
+      api.beginEdit(0, 'name');
+      api.setValue('Updated');
+
+      expect(api.getEditState()!.value).toBe('Updated');
+    });
+
+    it('does nothing when not editing', () => {
+      const { api } = setup();
+      api.setValue('noop');
+      expect(api.isEditing()).toBe(false);
+    });
+  });
+
+  describe('defineEditor', () => {
+    it('registers a custom editor', () => {
+      const { api } = setup();
+      api.defineEditor({
+        name: 'rating',
+        parse: (raw) => Number(raw),
+        format: (v) => `${v}★`,
+      });
+
+      const editor = api.getEditor('rating');
+      expect(editor).toBeDefined();
+      expect(editor!.format!(5)).toBe('5★');
+      expect(editor!.parse!('3')).toBe(3);
+    });
+  });
+
+  describe('built-in editors', () => {
+    it('text editor preserves strings', () => {
+      const { api } = setup();
+      const editor = api.getEditor('text')!;
+      expect(editor.parse!('hello')).toBe('hello');
+      expect(editor.format!('hello')).toBe('hello');
+      expect(editor.format!(null)).toBe('');
+    });
+
+    it('number editor parses and formats', () => {
+      const { api } = setup();
+      const editor = api.getEditor('number')!;
+      expect(editor.parse!('42')).toBe(42);
+      expect(editor.parse!('3.14')).toBe(3.14);
+      expect(editor.parse!('')).toBeNull();
+      expect(editor.parse!('abc')).toBeNull();
+      expect(editor.format!(42)).toBe('42');
+      expect(editor.format!(null)).toBe('');
+    });
+
+    it('checkbox editor parses and formats', () => {
+      const { api } = setup();
+      const editor = api.getEditor('checkbox')!;
+      expect(editor.parse!('true')).toBe(true);
+      expect(editor.parse!('false')).toBe(false);
+      expect(editor.format!(true)).toBe('true');
+      expect(editor.format!(false)).toBe('false');
+    });
+
+    it('date editor parses ISO date strings', () => {
+      const { api } = setup();
+      const editor = api.getEditor('date')!;
+      const parsed = editor.parse!('2025-03-15');
+      expect(parsed).toBeInstanceOf(Date);
+      expect(editor.format!(new Date('2025-03-15'))).toBe('2025-03-15');
+      expect(editor.format!(null)).toBe('');
+      expect(editor.parse!('')).toBeNull();
+    });
+
+    it('select editor preserves strings', () => {
+      const { api } = setup();
+      const editor = api.getEditor('select')!;
+      expect(editor.parse!('Seoul')).toBe('Seoul');
+      expect(editor.format!('Seoul')).toBe('Seoul');
+    });
+  });
+
+  describe('cell decorator', () => {
+    it('adds gs-cell--editing class to the active cell', () => {
+      const { grid, api } = setup();
+      api.beginEdit(0, 'name');
+
+      const decorations = grid.getCellDecorations(0, 'name');
+      expect(decorations.some((d) => d.className === 'gs-cell--editing')).toBe(true);
+    });
+
+    it('does not decorate non-editing cells', () => {
+      const { grid, api } = setup();
+      api.beginEdit(0, 'name');
+
+      const decorations = grid.getCellDecorations(1, 'name');
+      expect(decorations.some((d) => d.className === 'gs-cell--editing')).toBe(false);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('clears edit state on destroy', () => {
+      const { grid, api } = setup();
+      api.beginEdit(0, 'name');
+      grid.destroy();
+
+      // After destroy, getEditState should return null
+      expect(api.getEditState()).toBeNull();
+    });
+  });
+});

--- a/packages/core/src/editing.ts
+++ b/packages/core/src/editing.ts
@@ -1,0 +1,153 @@
+import type { CellValue, EditorDefinition, EditingPluginApi, EditState, GridPlugin } from './types';
+
+const builtinEditors: EditorDefinition[] = [
+  {
+    name: 'text',
+    parse: (raw) => raw,
+    format: (v) => (v == null ? '' : String(v)),
+  },
+  {
+    name: 'number',
+    parse: (raw) => {
+      if (raw === '' || raw === '-') return null;
+      const n = Number(raw);
+      return Number.isNaN(n) ? null : n;
+    },
+    format: (v) => (v == null ? '' : String(v)),
+  },
+  {
+    name: 'checkbox',
+    parse: (raw) => raw === 'true',
+    format: (v) => String(Boolean(v)),
+  },
+  {
+    name: 'date',
+    parse: (raw) => {
+      if (!raw) return null;
+      const d = new Date(raw);
+      return Number.isNaN(d.getTime()) ? null : d;
+    },
+    format: (v) => {
+      if (v instanceof Date) return v.toISOString().slice(0, 10);
+      if (v == null) return '';
+      return String(v);
+    },
+  },
+  {
+    name: 'select',
+    parse: (raw) => raw,
+    format: (v) => (v == null ? '' : String(v)),
+  },
+];
+
+export function createEditingPlugin(): GridPlugin {
+  const editors = new Map<string, EditorDefinition>();
+  for (const ed of builtinEditors) {
+    editors.set(ed.name, ed);
+  }
+
+  let editState: EditState | null = null;
+
+  const plugin: GridPlugin = {
+    name: 'editing',
+
+    init(ctx) {
+      const api: EditingPluginApi = {
+        beginEdit(rowIndex, columnId, initialChar) {
+          const cols = ctx.grid.columns.get();
+          const col = cols.find((c) => c.id === columnId);
+          if (!col || col.editable === false) return false;
+
+          // Auto-commit current edit before starting a new one
+          if (editState) {
+            api.commitEdit();
+          }
+
+          const originalValue = ctx.grid.getCell(rowIndex, columnId);
+
+          let value: CellValue;
+          if (initialChar !== undefined) {
+            // Type-to-edit: start with the typed character
+            value = initialChar;
+          } else {
+            value = originalValue;
+          }
+
+          editState = { rowIndex, columnId, value, originalValue };
+          ctx.events.emit('edit:begin', { ...editState });
+          return true;
+        },
+
+        commitEdit() {
+          if (!editState) return false;
+
+          const { rowIndex, columnId, value, originalValue } = editState;
+          const cols = ctx.grid.columns.get();
+          const col = cols.find((c) => c.id === columnId);
+          const editorName = col?.editor ?? col?.type ?? 'text';
+          const editor = editors.get(editorName);
+
+          // Parse string values through editor
+          let finalValue = value;
+          if (typeof value === 'string' && editor?.parse) {
+            finalValue = editor.parse(value);
+          }
+
+          editState = null;
+
+          ctx.grid.setCell(rowIndex, columnId, finalValue);
+          ctx.events.emit('edit:commit', {
+            rowIndex,
+            columnId,
+            oldValue: originalValue,
+            newValue: finalValue,
+          });
+          return true;
+        },
+
+        cancelEdit() {
+          if (!editState) return;
+          const { rowIndex, columnId } = editState;
+          editState = null;
+          ctx.events.emit('edit:cancel', { rowIndex, columnId });
+        },
+
+        getEditState() {
+          return editState ? { ...editState } : null;
+        },
+
+        isEditing() {
+          return editState !== null;
+        },
+
+        defineEditor(def) {
+          editors.set(def.name, def);
+        },
+
+        getEditor(name) {
+          return editors.get(name);
+        },
+
+        setValue(value) {
+          if (!editState) return;
+          editState = { ...editState, value };
+        },
+      };
+
+      ctx.expose('editing', api);
+
+      ctx.addCellDecorator(({ row, col }) => {
+        if (editState && editState.rowIndex === row && editState.columnId === col) {
+          return { className: 'gs-cell--editing' };
+        }
+        return null;
+      });
+
+      return () => {
+        editState = null;
+      };
+    },
+  };
+
+  return plugin;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,12 +22,16 @@ export type { Signal, Computed, ReadonlySignal, Unsubscribe } from './signal';
 export { createEventBus } from './events';
 export type { EventBus, EventHandler } from './events';
 
+// Editing
+export { createEditingPlugin } from './editing';
+
 // Types
 export type {
   CellValue,
   Row,
   ColumnType,
   PinPosition,
+  SelectOption,
   ColumnDef,
   SortDirection,
   SortEntry,
@@ -40,6 +44,9 @@ export type {
   VisibleRange,
   CellChange,
   GridEvents,
+  EditState,
+  EditorDefinition,
+  EditingPluginApi,
   CellDecoration,
   CellDecorator,
   PluginContext,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -13,6 +13,11 @@ export type ColumnType = 'text' | 'number' | 'date' | 'select' | 'checkbox';
 
 export type PinPosition = 'left' | 'right' | false;
 
+export interface SelectOption {
+  label: string;
+  value: string | number;
+}
+
 export interface ColumnDef {
   id: string;
   header: string;
@@ -25,6 +30,12 @@ export interface ColumnDef {
   filterable?: boolean;
   resizable?: boolean;
   visible?: boolean;
+  /** Whether this column is editable (default: true) */
+  editable?: boolean;
+  /** Editor type name — defaults to column `type` or 'text' */
+  editor?: string;
+  /** Options for select-type editors */
+  selectOptions?: SelectOption[];
 }
 
 // ─── Sort & Filter ─────────────────────────────────────────
@@ -99,9 +110,43 @@ export interface GridEvents {
   'sort:change': { sort: SortState };
   'filter:change': { filter: FilterState };
   'viewport:change': { viewport: ViewportState };
+  'edit:begin': EditState;
+  'edit:commit': {
+    rowIndex: number;
+    columnId: string;
+    oldValue: CellValue;
+    newValue: CellValue;
+  };
+  'edit:cancel': { rowIndex: number; columnId: string };
   'plugin:ready': { name: string };
   ready: undefined;
   destroy: undefined;
+}
+
+// ─── Editing ──────────────────────────────────────────────
+
+export interface EditState {
+  rowIndex: number;
+  columnId: string;
+  value: CellValue;
+  originalValue: CellValue;
+}
+
+export interface EditorDefinition {
+  name: string;
+  parse?: (raw: string) => CellValue;
+  format?: (value: CellValue) => string;
+}
+
+export interface EditingPluginApi {
+  beginEdit(rowIndex: number, columnId: string, initialChar?: string): boolean;
+  commitEdit(): boolean;
+  cancelEdit(): void;
+  getEditState(): EditState | null;
+  isEditing(): boolean;
+  defineEditor(def: EditorDefinition): void;
+  getEditor(name: string): EditorDefinition | undefined;
+  setValue(value: CellValue): void;
 }
 
 // ─── Plugin ────────────────────────────────────────────────

--- a/packages/react/src/cell-editor.tsx
+++ b/packages/react/src/cell-editor.tsx
@@ -1,0 +1,345 @@
+import type { CellValue, EditingPluginApi, GridInstance, SelectOption } from '@gridsmith/core';
+import {
+  type CSSProperties,
+  type KeyboardEvent,
+  type ReactNode,
+  memo,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+import type { CellEditorProps, GridColumnDef } from './types';
+
+// ─── Shared style & key handler ────────────────────────────
+
+const EDITOR_INPUT_STYLE: CSSProperties = {
+  width: '100%',
+  height: '100%',
+  border: 'none',
+  outline: 'none',
+  padding: 'inherit',
+  font: 'inherit',
+  boxSizing: 'border-box',
+  background: 'var(--gs-editor-bg, #fff)',
+};
+
+function useEditorKeyHandler(
+  onCommit: () => void,
+  onCancel: () => void,
+  onTab: (shift: boolean) => void,
+) {
+  return useCallback(
+    (e: KeyboardEvent<HTMLElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        onCommit();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+      } else if (e.key === 'Tab') {
+        e.preventDefault();
+        onTab(e.shiftKey);
+      }
+    },
+    [onCommit, onCancel, onTab],
+  );
+}
+
+// ─── Built-in editor inputs ─────────────────────────────────
+
+interface InputEditorProps {
+  value: string;
+  onChange: (v: string) => void;
+  onCommit: () => void;
+  onCancel: () => void;
+  onTab: (shift: boolean) => void;
+}
+
+function TextEditor({ value, onChange, onCommit, onCancel, onTab }: InputEditorProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const onKeyDown = useEditorKeyHandler(onCommit, onCancel, onTab);
+
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.focus();
+    el.select();
+  }, []);
+
+  return (
+    <input
+      ref={inputRef}
+      className="gs-editor-input"
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onKeyDown={onKeyDown}
+      onBlur={onCommit}
+      style={EDITOR_INPUT_STYLE}
+    />
+  );
+}
+
+function NumberEditor({ value, onChange, onCommit, onCancel, onTab }: InputEditorProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const onKeyDown = useEditorKeyHandler(onCommit, onCancel, onTab);
+
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.focus();
+    el.select();
+  }, []);
+
+  return (
+    <input
+      ref={inputRef}
+      className="gs-editor-input"
+      type="text"
+      inputMode="numeric"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onKeyDown={onKeyDown}
+      onBlur={onCommit}
+      style={EDITOR_INPUT_STYLE}
+    />
+  );
+}
+
+interface SelectEditorProps extends InputEditorProps {
+  options: SelectOption[];
+}
+
+function SelectEditor({ value, options, onChange, onCommit, onCancel, onTab }: SelectEditorProps) {
+  const selectRef = useRef<HTMLSelectElement>(null);
+  const onKeyDown = useEditorKeyHandler(onCommit, onCancel, onTab);
+
+  useEffect(() => {
+    selectRef.current?.focus();
+  }, []);
+
+  return (
+    <select
+      ref={selectRef}
+      className="gs-editor-select"
+      value={value}
+      onChange={(e) => {
+        // Auto-commit on selection change. `onChange` updates both local
+        // React state and the plugin synchronously, so `onCommit` reads the
+        // fresh value without needing a microtask deferral.
+        onChange(e.target.value);
+        onCommit();
+      }}
+      onKeyDown={onKeyDown}
+      onBlur={onCommit}
+      style={EDITOR_INPUT_STYLE}
+    >
+      {options.map((opt) => (
+        <option key={String(opt.value)} value={String(opt.value)}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function DateEditor({ value, onChange, onCommit, onCancel, onTab }: InputEditorProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const onKeyDown = useEditorKeyHandler(onCommit, onCancel, onTab);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  return (
+    <input
+      ref={inputRef}
+      className="gs-editor-input"
+      type="date"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onKeyDown={onKeyDown}
+      onBlur={onCommit}
+      style={EDITOR_INPUT_STYLE}
+    />
+  );
+}
+
+// ─── Main CellEditor ────────────────────────────────────────
+
+interface CellEditorOverlayProps {
+  grid: GridInstance;
+  editingApi: EditingPluginApi;
+  columns: GridColumnDef[];
+  columnIndex: number;
+  rowIndex: number;
+  editValue: CellValue;
+  columnId: string;
+  style: CSSProperties;
+}
+
+export const CellEditorOverlay = memo(function CellEditorOverlay({
+  grid,
+  editingApi,
+  columns,
+  columnIndex,
+  rowIndex,
+  editValue,
+  columnId,
+  style,
+}: CellEditorOverlayProps) {
+  const col = columns[columnIndex];
+  const editorType = col?.editor ?? col?.type ?? 'text';
+  const editor = editingApi.getEditor(editorType);
+
+  // Format the initial value for display in the editor.
+  const initialDisplay = editor?.format
+    ? editor.format(editValue)
+    : editValue == null
+      ? ''
+      : String(editValue);
+
+  // Local state holds the in-flight editor value so React can keep the
+  // controlled input in sync with user typing. Plugin state is kept up to date
+  // on every keystroke so `commitEdit()` reads the latest value.
+  const [localValue, setLocalValue] = useState(initialDisplay);
+
+  const handleChange = useCallback(
+    (v: string) => {
+      setLocalValue(v);
+      editingApi.setValue(v);
+    },
+    [editingApi],
+  );
+
+  const handleCommit = useCallback(() => {
+    editingApi.commitEdit();
+  }, [editingApi]);
+
+  const handleCancel = useCallback(() => {
+    editingApi.cancelEdit();
+  }, [editingApi]);
+
+  const handleTab = useCallback(
+    (shift: boolean) => {
+      // Commit current edit first.
+      editingApi.commitEdit();
+
+      // Find next editable, visible column.
+      const editableColumns = columns
+        .map((c, i) => ({ col: c, index: i }))
+        .filter((x) => x.col.visible !== false && x.col.editable !== false);
+
+      const currentIdx = editableColumns.findIndex((x) => x.col.id === columnId);
+      if (currentIdx === -1) return;
+
+      let nextRow = rowIndex;
+      let nextEditableIdx: number;
+
+      if (shift) {
+        nextEditableIdx = currentIdx - 1;
+        if (nextEditableIdx < 0) {
+          nextEditableIdx = editableColumns.length - 1;
+          nextRow = Math.max(0, rowIndex - 1);
+        }
+      } else {
+        nextEditableIdx = currentIdx + 1;
+        if (nextEditableIdx >= editableColumns.length) {
+          nextEditableIdx = 0;
+          nextRow = Math.min(grid.rowCount - 1, rowIndex + 1);
+        }
+      }
+
+      const next = editableColumns[nextEditableIdx];
+      if (next) {
+        editingApi.beginEdit(nextRow, next.col.id);
+      }
+    },
+    [editingApi, columns, columnId, rowIndex, grid],
+  );
+
+  // Guard after all hooks to keep hook order stable.
+  if (!col) return null;
+
+  // Custom editor: let the caller render whatever React node they want.
+  if (col.cellEditor) {
+    const row: Record<string, CellValue> = {};
+    for (const c of columns) {
+      row[c.id] = grid.getCell(rowIndex, c.id);
+    }
+
+    const editorProps: CellEditorProps = {
+      value: editValue,
+      row,
+      rowIndex,
+      column: col,
+      commit: (value: CellValue) => {
+        editingApi.setValue(value);
+        editingApi.commitEdit();
+      },
+      cancel: handleCancel,
+    };
+
+    return (
+      <div className="gs-cell-editor" style={style}>
+        {col.cellEditor(editorProps)}
+      </div>
+    );
+  }
+
+  // Checkbox is toggled inline by the Grid component; no overlay.
+  if (editorType === 'checkbox') return null;
+
+  let editorElement: ReactNode;
+
+  if (editorType === 'select') {
+    editorElement = (
+      <SelectEditor
+        value={localValue}
+        options={col.selectOptions ?? []}
+        onChange={handleChange}
+        onCommit={handleCommit}
+        onCancel={handleCancel}
+        onTab={handleTab}
+      />
+    );
+  } else if (editorType === 'date') {
+    editorElement = (
+      <DateEditor
+        value={localValue}
+        onChange={handleChange}
+        onCommit={handleCommit}
+        onCancel={handleCancel}
+        onTab={handleTab}
+      />
+    );
+  } else if (editorType === 'number') {
+    editorElement = (
+      <NumberEditor
+        value={localValue}
+        onChange={handleChange}
+        onCommit={handleCommit}
+        onCancel={handleCancel}
+        onTab={handleTab}
+      />
+    );
+  } else {
+    editorElement = (
+      <TextEditor
+        value={localValue}
+        onChange={handleChange}
+        onCommit={handleCommit}
+        onCancel={handleCancel}
+        onTab={handleTab}
+      />
+    );
+  }
+
+  return (
+    <div className="gs-cell-editor" style={style}>
+      {editorElement}
+    </div>
+  );
+});

--- a/packages/react/src/editing.spec.tsx
+++ b/packages/react/src/editing.spec.tsx
@@ -1,0 +1,174 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import { Grid } from './grid';
+import type { GridColumnDef } from './types';
+
+// ─── DOM mocks ────────────────────────────────────────────
+
+const origCW = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+const origCH = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+
+beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    get() {
+      return 500;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    get() {
+      return 300;
+    },
+  });
+
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+afterEach(() => {
+  if (origCW) Object.defineProperty(HTMLElement.prototype, 'clientWidth', origCW);
+  if (origCH) Object.defineProperty(HTMLElement.prototype, 'clientHeight', origCH);
+  vi.restoreAllMocks();
+});
+
+// ─── Fixtures ─────────────────────────────────────────────
+
+const columns: GridColumnDef[] = [
+  { id: 'name', header: 'Name', type: 'text' },
+  { id: 'age', header: 'Age', type: 'number' },
+  { id: 'active', header: 'Active', type: 'checkbox' },
+  { id: 'readonly', header: 'ReadOnly', type: 'text', editable: false },
+];
+
+const data = [
+  { name: 'Alice', age: 30, active: true, readonly: 'fixed' },
+  { name: 'Bob', age: 25, active: false, readonly: 'fixed' },
+];
+
+function renderGrid(props?: Partial<Parameters<typeof Grid>[0]>) {
+  return render(<Grid data={data} columns={columns} {...props} />);
+}
+
+function findCell(row: number, col: string): HTMLElement | null {
+  return document.querySelector(`[data-row="${row}"][data-col="${col}"]`);
+}
+
+describe('Grid editing integration', () => {
+  it('renders data-row and data-col attributes on cells', () => {
+    renderGrid();
+    const cell = findCell(0, 'name');
+    expect(cell).toBeTruthy();
+    expect(cell!.textContent).toBe('Alice');
+  });
+
+  it('opens editor on double-click', () => {
+    renderGrid();
+    const cell = findCell(0, 'name')!;
+    fireEvent.doubleClick(cell);
+
+    const editor = document.querySelector('.gs-cell-editor');
+    expect(editor).toBeTruthy();
+
+    const input = editor!.querySelector('input');
+    expect(input).toBeTruthy();
+    expect(input!.value).toBe('Alice');
+  });
+
+  it('does not open editor on double-click for read-only columns', () => {
+    renderGrid();
+    const cell = findCell(0, 'readonly')!;
+    fireEvent.doubleClick(cell);
+
+    const editor = document.querySelector('.gs-cell-editor');
+    expect(editor).toBeNull();
+  });
+
+  it('commits edit on Enter', () => {
+    const onCellChange = vi.fn();
+    renderGrid({ onCellChange });
+    const cell = findCell(0, 'name')!;
+
+    // Double-click to open editor
+    fireEvent.doubleClick(cell);
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    expect(input).toBeTruthy();
+
+    // Change value and press Enter
+    fireEvent.change(input, { target: { value: 'Eve' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onCellChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        col: 'name',
+        newValue: 'Eve',
+      }),
+    );
+
+    // Editor should be closed
+    expect(document.querySelector('.gs-cell-editor')).toBeNull();
+  });
+
+  it('cancels edit on Escape', () => {
+    const onCellChange = vi.fn();
+    renderGrid({ onCellChange });
+    const cell = findCell(0, 'name')!;
+
+    fireEvent.doubleClick(cell);
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: 'Changed' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    // No data change should have been emitted for this edit
+    expect(onCellChange).not.toHaveBeenCalled();
+    expect(document.querySelector('.gs-cell-editor')).toBeNull();
+  });
+
+  it('toggles checkbox on click', () => {
+    const onCellChange = vi.fn();
+    renderGrid({ onCellChange });
+    const cell = findCell(0, 'active')!;
+
+    fireEvent.click(cell);
+
+    expect(onCellChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        col: 'active',
+        oldValue: true,
+        newValue: false,
+      }),
+    );
+  });
+
+  it('has tabIndex on the grid root for keyboard focus', () => {
+    renderGrid();
+    const gridRoot = document.querySelector('.gs-grid');
+    expect(gridRoot).toBeTruthy();
+    expect(gridRoot!.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('preserves in-flight edit value across re-renders', () => {
+    // Regression guard: the editor's controlled input must stay in sync with
+    // user typing even when the Grid re-renders for unrelated reasons.
+    const { rerender } = render(<Grid data={data} columns={columns} />);
+    const cell = findCell(0, 'name')!;
+    fireEvent.doubleClick(cell);
+
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Typed' } });
+
+    // Force a re-render unrelated to the edit.
+    rerender(<Grid data={data} columns={columns} rowHeight={33} />);
+
+    const inputAfter = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    expect(inputAfter.value).toBe('Typed');
+  });
+});

--- a/packages/react/src/editing.spec.tsx
+++ b/packages/react/src/editing.spec.tsx
@@ -1,8 +1,8 @@
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
 import { Grid } from './grid';
-import type { GridColumnDef } from './types';
+import type { CellEditorProps, GridColumnDef } from './types';
 
 // ─── DOM mocks ────────────────────────────────────────────
 
@@ -59,6 +59,12 @@ function renderGrid(props?: Partial<Parameters<typeof Grid>[0]>) {
 
 function findCell(row: number, col: string): HTMLElement | null {
   return document.querySelector(`[data-row="${row}"][data-col="${col}"]`);
+}
+
+function getGridRoot(): HTMLElement {
+  const root = document.querySelector('.gs-grid');
+  if (!root) throw new Error('Grid root not found');
+  return root as HTMLElement;
 }
 
 describe('Grid editing integration', () => {
@@ -148,6 +154,19 @@ describe('Grid editing integration', () => {
     );
   });
 
+  it('toggles checkbox on double-click', () => {
+    const onCellChange = vi.fn();
+    renderGrid({ onCellChange });
+    const cell = findCell(1, 'active')!;
+
+    fireEvent.doubleClick(cell);
+
+    expect(onCellChange).toHaveBeenCalledWith(
+      expect.objectContaining({ col: 'active', oldValue: false, newValue: true }),
+    );
+    expect(document.querySelector('.gs-cell-editor')).toBeNull();
+  });
+
   it('has tabIndex on the grid root for keyboard focus', () => {
     renderGrid();
     const gridRoot = document.querySelector('.gs-grid');
@@ -170,5 +189,413 @@ describe('Grid editing integration', () => {
 
     const inputAfter = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
     expect(inputAfter.value).toBe('Typed');
+  });
+
+  it('opens number editor on double-click and commits numeric value', () => {
+    const onCellChange = vi.fn();
+    renderGrid({ onCellChange });
+    const cell = findCell(0, 'age')!;
+    fireEvent.doubleClick(cell);
+
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    expect(input.value).toBe('30');
+    expect(input.inputMode).toBe('numeric');
+
+    fireEvent.change(input, { target: { value: '42' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onCellChange).toHaveBeenCalledWith(
+      expect.objectContaining({ col: 'age', newValue: 42 }),
+    );
+  });
+
+  it('opens select editor with options on double-click', () => {
+    const selectColumns: GridColumnDef[] = [
+      {
+        id: 'status',
+        header: 'Status',
+        type: 'select',
+        selectOptions: [
+          { label: 'Active', value: 'active' },
+          { label: 'Inactive', value: 'inactive' },
+        ],
+      },
+    ];
+    const selectData = [{ status: 'active' }, { status: 'inactive' }];
+    const onCellChange = vi.fn();
+
+    render(<Grid data={selectData} columns={selectColumns} onCellChange={onCellChange} />);
+
+    const cell = findCell(0, 'status')!;
+    fireEvent.doubleClick(cell);
+
+    const select = document.querySelector('.gs-cell-editor select') as HTMLSelectElement;
+    expect(select).toBeTruthy();
+    expect(select.value).toBe('active');
+    expect(select.options).toHaveLength(2);
+
+    // Selecting a new value auto-commits.
+    fireEvent.change(select, { target: { value: 'inactive' } });
+
+    expect(onCellChange).toHaveBeenCalledWith(
+      expect.objectContaining({ col: 'status', newValue: 'inactive' }),
+    );
+  });
+
+  it('opens date editor on double-click', () => {
+    const dateColumns: GridColumnDef[] = [{ id: 'dob', header: 'DOB', type: 'date' }];
+    const dateData = [{ dob: new Date('2020-01-15') }];
+
+    render(<Grid data={dateData} columns={dateColumns} />);
+
+    const cell = findCell(0, 'dob')!;
+    fireEvent.doubleClick(cell);
+
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    expect(input.type).toBe('date');
+  });
+
+  it('uses custom cellEditor when provided', () => {
+    const customColumns: GridColumnDef[] = [
+      {
+        id: 'name',
+        header: 'Name',
+        type: 'text',
+        cellEditor: ({ value, commit, cancel }: CellEditorProps) => (
+          <div className="custom-editor">
+            <button type="button" onClick={() => commit('CUSTOM')}>
+              set
+            </button>
+            <button type="button" onClick={cancel}>
+              cancel
+            </button>
+            <span>{String(value)}</span>
+          </div>
+        ),
+      },
+    ];
+    const onCellChange = vi.fn();
+    render(<Grid data={[{ name: 'Old' }]} columns={customColumns} onCellChange={onCellChange} />);
+
+    const cell = findCell(0, 'name')!;
+    fireEvent.doubleClick(cell);
+
+    const custom = document.querySelector('.custom-editor');
+    expect(custom).toBeTruthy();
+
+    const setBtn = custom!.querySelectorAll('button')[0]!;
+    fireEvent.click(setBtn);
+
+    expect(onCellChange).toHaveBeenCalledWith(
+      expect.objectContaining({ col: 'name', newValue: 'CUSTOM' }),
+    );
+  });
+
+  it('custom cellEditor cancel callback closes the editor without change', () => {
+    const customColumns: GridColumnDef[] = [
+      {
+        id: 'name',
+        header: 'Name',
+        type: 'text',
+        cellEditor: ({ cancel }: CellEditorProps) => (
+          <button className="cancel-btn" type="button" onClick={cancel}>
+            cancel
+          </button>
+        ),
+      },
+    ];
+    const onCellChange = vi.fn();
+    render(<Grid data={[{ name: 'Old' }]} columns={customColumns} onCellChange={onCellChange} />);
+
+    fireEvent.doubleClick(findCell(0, 'name')!);
+    const btn = document.querySelector('.cancel-btn')!;
+    fireEvent.click(btn);
+
+    expect(document.querySelector('.gs-cell-editor')).toBeNull();
+    expect(onCellChange).not.toHaveBeenCalled();
+  });
+
+  it('F2 opens editor on focused cell', () => {
+    renderGrid();
+    const cell = findCell(0, 'name')!;
+    fireEvent.click(cell); // focus
+
+    const gridRoot = getGridRoot();
+    fireEvent.keyDown(gridRoot, { key: 'F2' });
+
+    const editor = document.querySelector('.gs-cell-editor');
+    expect(editor).toBeTruthy();
+    expect(editor!.querySelector('input')!.value).toBe('Alice');
+  });
+
+  it('Enter opens editor on focused non-checkbox cell', () => {
+    renderGrid();
+    fireEvent.click(findCell(0, 'name')!);
+
+    fireEvent.keyDown(getGridRoot(), { key: 'Enter' });
+
+    const editor = document.querySelector('.gs-cell-editor');
+    expect(editor).toBeTruthy();
+  });
+
+  it('Enter toggles checkbox on focused cell', () => {
+    const onCellChange = vi.fn();
+    renderGrid({ onCellChange });
+    fireEvent.click(findCell(1, 'active')!); // toggles once on click
+
+    onCellChange.mockClear();
+    fireEvent.keyDown(getGridRoot(), { key: 'Enter' });
+
+    expect(onCellChange).toHaveBeenCalledWith(expect.objectContaining({ col: 'active' }));
+  });
+
+  it('Delete clears focused cell value', () => {
+    const onCellChange = vi.fn();
+    renderGrid({ onCellChange });
+    fireEvent.click(findCell(0, 'name')!);
+
+    fireEvent.keyDown(getGridRoot(), { key: 'Delete' });
+
+    expect(onCellChange).toHaveBeenCalledWith(
+      expect.objectContaining({ col: 'name', oldValue: 'Alice', newValue: null }),
+    );
+  });
+
+  it('Backspace clears focused cell value', () => {
+    const onCellChange = vi.fn();
+    renderGrid({ onCellChange });
+    fireEvent.click(findCell(0, 'name')!);
+
+    fireEvent.keyDown(getGridRoot(), { key: 'Backspace' });
+
+    expect(onCellChange).toHaveBeenCalledWith(
+      expect.objectContaining({ col: 'name', oldValue: 'Alice', newValue: null }),
+    );
+  });
+
+  it('Delete on read-only cell is a no-op', () => {
+    const onCellChange = vi.fn();
+    renderGrid({ onCellChange });
+    fireEvent.click(findCell(0, 'readonly')!);
+
+    fireEvent.keyDown(getGridRoot(), { key: 'Delete' });
+
+    expect(onCellChange).not.toHaveBeenCalled();
+  });
+
+  it('type-to-edit starts editor with typed character', () => {
+    renderGrid();
+    fireEvent.click(findCell(0, 'name')!);
+
+    fireEvent.keyDown(getGridRoot(), { key: 'x' });
+
+    const editor = document.querySelector('.gs-cell-editor');
+    expect(editor).toBeTruthy();
+    const input = editor!.querySelector('input') as HTMLInputElement;
+    // beginEdit(row, col, 'x') sets the initial value to 'x'
+    expect(input.value).toBe('x');
+  });
+
+  it('type-to-edit accepts digits on number columns', () => {
+    renderGrid();
+    fireEvent.click(findCell(0, 'age')!);
+
+    fireEvent.keyDown(getGridRoot(), { key: '5' });
+
+    const editor = document.querySelector('.gs-cell-editor');
+    expect(editor).toBeTruthy();
+    const input = editor!.querySelector('input') as HTMLInputElement;
+    expect(input.value).toBe('5');
+  });
+
+  it('type-to-edit rejects non-numeric characters on number columns', () => {
+    renderGrid();
+    fireEvent.click(findCell(0, 'age')!);
+
+    fireEvent.keyDown(getGridRoot(), { key: 'x' });
+
+    expect(document.querySelector('.gs-cell-editor')).toBeNull();
+  });
+
+  it('type-to-edit is a no-op on checkbox columns', () => {
+    renderGrid();
+    fireEvent.click(findCell(0, 'active')!); // this toggles it; clear first
+    fireEvent.click(findCell(1, 'active')!);
+
+    fireEvent.keyDown(getGridRoot(), { key: 'a' });
+
+    expect(document.querySelector('.gs-cell-editor')).toBeNull();
+  });
+
+  it('type-to-edit ignores modifier keys', () => {
+    renderGrid();
+    fireEvent.click(findCell(0, 'name')!);
+
+    fireEvent.keyDown(getGridRoot(), { key: 'a', ctrlKey: true });
+
+    expect(document.querySelector('.gs-cell-editor')).toBeNull();
+  });
+
+  it('keydown with no focused cell is a no-op', () => {
+    renderGrid();
+
+    // No focused cell yet
+    expect(() => fireEvent.keyDown(getGridRoot(), { key: 'F2' })).not.toThrow();
+    expect(document.querySelector('.gs-cell-editor')).toBeNull();
+  });
+
+  it('does not re-trigger key handling while editing', () => {
+    renderGrid();
+    fireEvent.doubleClick(findCell(0, 'name')!);
+
+    // The root key handler should bail early; the editor input handles keys.
+    expect(() => fireEvent.keyDown(getGridRoot(), { key: 'F2' })).not.toThrow();
+
+    // Editor is still open (no second beginEdit side effect)
+    expect(document.querySelector('.gs-cell-editor')).toBeTruthy();
+  });
+
+  it('Tab commits and moves to next editable column', () => {
+    const onCellChange = vi.fn();
+    renderGrid({ onCellChange });
+    fireEvent.doubleClick(findCell(0, 'name')!);
+
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Next' } });
+    fireEvent.keyDown(input, { key: 'Tab' });
+
+    expect(onCellChange).toHaveBeenCalledWith(
+      expect.objectContaining({ col: 'name', newValue: 'Next' }),
+    );
+
+    // Editor should move to the 'age' column (next editable) on row 0
+    const editor = document.querySelector('.gs-cell-editor');
+    expect(editor).toBeTruthy();
+    const nextInput = editor!.querySelector('input') as HTMLInputElement;
+    expect(nextInput.value).toBe('30');
+  });
+
+  it('Shift+Tab moves to previous editable column', () => {
+    renderGrid();
+    fireEvent.doubleClick(findCell(0, 'age')!);
+
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    fireEvent.keyDown(input, { key: 'Tab', shiftKey: true });
+
+    // Should move back to 'name' on row 0
+    const nextInput = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    expect(nextInput.value).toBe('Alice');
+  });
+
+  it('Tab from last editable column wraps to first column of next row', () => {
+    // Columns in order: name, age, active (checkbox — editor skips), readonly (not editable)
+    // Editable columns: [name, age] (checkbox is filtered by visible/editable default true,
+    // but handleTab does NOT special-case checkbox; it only filters editable!==false.)
+    // Pick a simpler fixture to avoid checkbox filtering complexity.
+    const cols: GridColumnDef[] = [
+      { id: 'a', header: 'A', type: 'text' },
+      { id: 'b', header: 'B', type: 'text' },
+    ];
+    const rows = [
+      { a: 'a0', b: 'b0' },
+      { a: 'a1', b: 'b1' },
+    ];
+    render(<Grid data={rows} columns={cols} />);
+
+    fireEvent.doubleClick(findCell(0, 'b')!);
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    fireEvent.keyDown(input, { key: 'Tab' });
+
+    const next = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    // Wraps to first editable on next row → (1, 'a')
+    expect(next.value).toBe('a1');
+  });
+
+  it('Shift+Tab from first editable column wraps to last column of previous row', () => {
+    const cols: GridColumnDef[] = [
+      { id: 'a', header: 'A', type: 'text' },
+      { id: 'b', header: 'B', type: 'text' },
+    ];
+    const rows = [
+      { a: 'a0', b: 'b0' },
+      { a: 'a1', b: 'b1' },
+    ];
+    render(<Grid data={rows} columns={cols} />);
+
+    fireEvent.doubleClick(findCell(1, 'a')!);
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    fireEvent.keyDown(input, { key: 'Tab', shiftKey: true });
+
+    const next = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    // Wraps to last editable on previous row → (0, 'b')
+    expect(next.value).toBe('b0');
+  });
+
+  it('clicking a different cell while editing commits the current edit', () => {
+    const onCellChange = vi.fn();
+    renderGrid({ onCellChange });
+    fireEvent.doubleClick(findCell(0, 'name')!);
+
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Committed' } });
+
+    // Click a different cell while editing
+    fireEvent.click(findCell(1, 'name')!);
+
+    expect(onCellChange).toHaveBeenCalledWith(
+      expect.objectContaining({ col: 'name', newValue: 'Committed' }),
+    );
+  });
+
+  it('focused cell is cleared on sort change', () => {
+    // Use controlled sort so we can flip sortState without user interaction.
+    const { rerender } = render(<Grid data={data} columns={columns} sortState={[]} />);
+
+    fireEvent.click(findCell(0, 'name')!);
+
+    // Now change sort; focusedCell should be cleared (F2 should be a no-op).
+    act(() => {
+      rerender(
+        <Grid data={data} columns={columns} sortState={[{ columnId: 'name', direction: 'asc' }]} />,
+      );
+    });
+
+    fireEvent.keyDown(getGridRoot(), { key: 'F2' });
+    expect(document.querySelector('.gs-cell-editor')).toBeNull();
+  });
+
+  it('focused cell is cleared on filter change', () => {
+    const { rerender } = render(<Grid data={data} columns={columns} filterState={[]} />);
+
+    fireEvent.click(findCell(0, 'name')!);
+
+    act(() => {
+      rerender(
+        <Grid
+          data={data}
+          columns={columns}
+          filterState={[{ columnId: 'name', operator: 'contains', value: 'A' }]}
+        />,
+      );
+    });
+
+    fireEvent.keyDown(getGridRoot(), { key: 'F2' });
+    expect(document.querySelector('.gs-cell-editor')).toBeNull();
+  });
+
+  it('commits on blur of text editor', () => {
+    const onCellChange = vi.fn();
+    renderGrid({ onCellChange });
+    fireEvent.doubleClick(findCell(0, 'name')!);
+
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Blurred' } });
+    fireEvent.blur(input);
+
+    expect(onCellChange).toHaveBeenCalledWith(
+      expect.objectContaining({ col: 'name', newValue: 'Blurred' }),
+    );
   });
 });

--- a/packages/react/src/grid.tsx
+++ b/packages/react/src/grid.tsx
@@ -1,10 +1,13 @@
 import {
   type CellValue,
+  type EditingPluginApi,
+  type EditState,
   type GridInstance,
   type Row,
   type VisibleRange,
   calculateVisibleRange,
   computeColumnLayout,
+  createEditingPlugin,
   getTotalHeight,
   DEFAULT_CONFIG,
 } from '@gridsmith/core';
@@ -19,6 +22,7 @@ import {
   useState,
 } from 'react';
 
+import { CellEditorOverlay } from './cell-editor';
 import type { GridProps } from './types';
 import { useGrid } from './use-grid';
 import { useSignalValue } from './use-signal';
@@ -51,6 +55,12 @@ function buildRowData(grid: GridInstance, viewIndex: number, columnIds: string[]
 
 // ─── Grid Component ────────────────────────────────────────
 
+/** Check if a keydown event is a printable character for type-to-edit. */
+function isPrintableKey(e: KeyboardEvent): boolean {
+  if (e.ctrlKey || e.metaKey || e.altKey) return false;
+  return e.key.length === 1;
+}
+
 export const Grid = memo(function Grid({
   data,
   columns,
@@ -67,7 +77,17 @@ export const Grid = memo(function Grid({
   onFilterChange,
 }: GridProps) {
   const headerHeight = headerHeightProp ?? rowHeight;
-  const grid = useGrid({ data, columns, plugins });
+
+  // Inject editing plugin automatically. `useGrid` creates the grid once
+  // via `useState`, so the plugin list is consumed a single time on mount.
+  // Use a lazy `useState` to make the one-shot nature explicit and avoid
+  // constructing throwaway plugin instances on every render.
+  const [allPlugins] = useState(() => {
+    const editingPlugin = createEditingPlugin();
+    return plugins ? [editingPlugin, ...plugins] : [editingPlugin];
+  });
+
+  const grid = useGrid({ data, columns, plugins: allPlugins });
 
   // ─── Controlled state sync ─────────────────────────────
 
@@ -103,6 +123,42 @@ export const Grid = memo(function Grid({
     if (!onFilterChange) return;
     return grid.subscribe('filter:change', ({ filter }) => onFilterChange(filter));
   }, [grid, onFilterChange]);
+
+  // ─── Editing state ─────────────────────────────────────
+
+  const editingApi = useMemo(() => {
+    const api = grid.getPlugin<EditingPluginApi>('editing');
+    if (!api) throw new Error('Editing plugin not found — this should not happen');
+    return api;
+  }, [grid]);
+
+  const [editState, setEditState] = useState<EditState | null>(null);
+  const [focusedCell, setFocusedCell] = useState<{
+    row: number;
+    col: string;
+    colIndex: number;
+  } | null>(null);
+
+  useEffect(() => {
+    const unsubs = [
+      grid.subscribe('edit:begin', (state) => setEditState({ ...state })),
+      grid.subscribe('edit:commit', () => setEditState(null)),
+      grid.subscribe('edit:cancel', () => setEditState(null)),
+    ];
+    return () => unsubs.forEach((u) => u());
+  }, [grid]);
+
+  // Clear focused cell when sort/filter/data/columns change, since view
+  // indices may no longer refer to the same underlying row.
+  useEffect(() => {
+    const unsubs = [
+      grid.subscribe('sort:change', () => setFocusedCell(null)),
+      grid.subscribe('filter:change', () => setFocusedCell(null)),
+      grid.subscribe('data:rowsUpdate', () => setFocusedCell(null)),
+      grid.subscribe('columns:update', () => setFocusedCell(null)),
+    ];
+    return () => unsubs.forEach((u) => u());
+  }, [grid]);
 
   // ─── Reactive state from core ──────────────────────────
 
@@ -290,7 +346,14 @@ export const Grid = memo(function Grid({
         }
 
         cells.push(
-          <div key={col.id} className={cellClassName} style={cellStyle} {...attrs}>
+          <div
+            key={col.id}
+            className={cellClassName}
+            style={cellStyle}
+            data-row={r}
+            data-col={col.id}
+            {...attrs}
+          >
             {content}
           </div>,
         );
@@ -316,6 +379,158 @@ export const Grid = memo(function Grid({
     return result;
   }, [visibleRange, totalRows, columns, grid, columnLayout, columnIds, rowHeight, dataVersion]);
 
+  // ─── Cell interaction handlers ──────────────────────────
+
+  const parseCellFromTarget = useCallback(
+    (target: EventTarget | null): { row: number; col: string; colIndex: number } | null => {
+      const el = (target as HTMLElement | null)?.closest?.('.gs-cell') as HTMLElement | null;
+      if (!el) return null;
+      const row = Number(el.dataset.row);
+      const col = el.dataset.col;
+      if (col == null || Number.isNaN(row)) return null;
+      const colIndex = currentColumns.findIndex((c) => c.id === col);
+      if (colIndex === -1) return null;
+      return { row, col, colIndex };
+    },
+    [currentColumns],
+  );
+
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent) => {
+      const cell = parseCellFromTarget(e.target);
+      if (!cell) return;
+      const colDef = currentColumns[cell.colIndex];
+      if (!colDef || colDef.editable === false) return;
+
+      const editorType = colDef.editor ?? colDef.type ?? 'text';
+      if (editorType === 'checkbox') {
+        // Checkbox: toggle on double-click
+        const current = grid.getCell(cell.row, cell.col);
+        grid.setCell(cell.row, cell.col, !current);
+      } else {
+        editingApi.beginEdit(cell.row, cell.col);
+      }
+      setFocusedCell(cell);
+    },
+    [parseCellFromTarget, currentColumns, editingApi, grid],
+  );
+
+  const handleCellClick = useCallback(
+    (e: React.MouseEvent) => {
+      const cell = parseCellFromTarget(e.target);
+      if (!cell) return;
+
+      // If clicking a different cell while editing, commit current edit
+      if (editState && (editState.rowIndex !== cell.row || editState.columnId !== cell.col)) {
+        editingApi.commitEdit();
+      }
+
+      setFocusedCell(cell);
+
+      // Checkbox: toggle on single click
+      const colDef = currentColumns[cell.colIndex];
+      if (colDef && colDef.editable !== false) {
+        const editorType = colDef.editor ?? colDef.type ?? 'text';
+        if (editorType === 'checkbox') {
+          const current = grid.getCell(cell.row, cell.col);
+          grid.setCell(cell.row, cell.col, !current);
+        }
+      }
+    },
+    [parseCellFromTarget, editState, editingApi, currentColumns, grid],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      // If currently editing, the editor handles its own keys
+      if (editState) return;
+
+      if (!focusedCell) return;
+
+      if (e.key === 'F2') {
+        e.preventDefault();
+        editingApi.beginEdit(focusedCell.row, focusedCell.col);
+        return;
+      }
+
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const colDef = currentColumns[focusedCell.colIndex];
+        if (colDef && colDef.editable !== false) {
+          const editorType = colDef.editor ?? colDef.type ?? 'text';
+          if (editorType === 'checkbox') {
+            const current = grid.getCell(focusedCell.row, focusedCell.col);
+            grid.setCell(focusedCell.row, focusedCell.col, !current);
+          } else {
+            editingApi.beginEdit(focusedCell.row, focusedCell.col);
+          }
+        }
+        return;
+      }
+
+      if (e.key === 'Delete' || e.key === 'Backspace') {
+        e.preventDefault();
+        const colDef = currentColumns[focusedCell.colIndex];
+        if (colDef && colDef.editable !== false) {
+          grid.setCell(focusedCell.row, focusedCell.col, null);
+        }
+        return;
+      }
+
+      // Type-to-edit: printable character starts editing
+      if (isPrintableKey(e.nativeEvent)) {
+        const colDef = currentColumns[focusedCell.colIndex];
+        if (colDef && colDef.editable !== false) {
+          const editorType = colDef.editor ?? colDef.type ?? 'text';
+          if (editorType === 'checkbox' || editorType === 'select') return;
+          // For number editors, only start editing on characters that can
+          // begin a number literal. Otherwise a stray letter would wipe the
+          // cell to null on commit.
+          if (editorType === 'number' && !/^[-0-9.]$/.test(e.key)) return;
+          e.preventDefault();
+          editingApi.beginEdit(focusedCell.row, focusedCell.col, e.key);
+        }
+      }
+    },
+    [editState, focusedCell, currentColumns, editingApi, grid],
+  );
+
+  // ─── Editor overlay ───────────────────────────────────
+
+  const editorOverlay = useMemo(() => {
+    if (!editState) return null;
+
+    const colIndex = currentColumns.findIndex((c) => c.id === editState.columnId);
+    if (colIndex === -1) return null;
+
+    const editorStyle: CSSProperties = {
+      position: 'absolute',
+      top: editState.rowIndex * rowHeight,
+      left: columnLayout.offsets[colIndex],
+      width: columnLayout.widths[colIndex],
+      height: rowHeight,
+      zIndex: 10,
+      boxSizing: 'border-box',
+      display: 'flex',
+      alignItems: 'stretch',
+    };
+
+    return (
+      <CellEditorOverlay
+        // Remount editor on every new edit so local input state resets.
+        key={`${editState.rowIndex}:${editState.columnId}`}
+        grid={grid}
+        editingApi={editingApi}
+        columns={columns}
+        columnIndex={colIndex}
+        rowIndex={editState.rowIndex}
+        editValue={editState.value}
+        columnId={editState.columnId}
+        style={editorStyle}
+      />
+    );
+  }, [editState, currentColumns, columnLayout, rowHeight, grid, editingApi, columns]);
+
   // ─── JSX ───────────────────────────────────────────────
 
   return (
@@ -327,6 +542,8 @@ export const Grid = memo(function Grid({
         display: 'flex',
         flexDirection: 'column',
       }}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
     >
       <div
         className="gs-header"
@@ -355,6 +572,8 @@ export const Grid = memo(function Grid({
           overflow: 'auto',
           flex: 1,
         }}
+        onClick={handleCellClick}
+        onDoubleClick={handleDoubleClick}
       >
         <div
           className="gs-canvas"
@@ -365,6 +584,7 @@ export const Grid = memo(function Grid({
           }}
         >
           {rowElements}
+          {editorOverlay}
         </div>
       </div>
     </div>

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -9,7 +9,7 @@ export { useGridSelection } from './use-grid-selection';
 export type { SelectionState } from './use-grid-selection';
 
 // Types
-export type { GridProps, GridColumnDef, CellRendererProps } from './types';
+export type { GridProps, GridColumnDef, CellRendererProps, CellEditorProps } from './types';
 
 // Re-export core types commonly needed with the React adapter
 export {
@@ -17,6 +17,7 @@ export {
   type Row,
   type ColumnDef,
   type ColumnType,
+  type SelectOption,
   type SortState,
   type SortEntry,
   type SortDirection,
@@ -24,8 +25,12 @@ export {
   type FilterEntry,
   type FilterOperator,
   type CellChange,
+  type EditState,
+  type EditorDefinition,
+  type EditingPluginApi,
   type GridInstance,
   type GridPlugin,
   type GridOptions,
+  createEditingPlugin,
   VERSION,
 } from '@gridsmith/core';

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -17,9 +17,21 @@ export interface CellRendererProps {
   column: GridColumnDef;
 }
 
+/** Props passed to custom cell editor components. */
+export interface CellEditorProps {
+  value: CellValue;
+  row: Row;
+  rowIndex: number;
+  column: GridColumnDef;
+  commit: (value: CellValue) => void;
+  cancel: () => void;
+}
+
 /** Extended column definition with React-specific fields. */
 export interface GridColumnDef extends ColumnDef {
   cellRenderer?: (props: CellRendererProps) => ReactNode;
+  /** Custom React editor component for this column. */
+  cellEditor?: (props: CellEditorProps) => ReactNode;
 }
 
 /** Props for the Grid component. */


### PR DESCRIPTION
## Summary

- Add `@gridsmith/core` editing plugin: headless state machine for begin/commit/cancel edits with pluggable `EditorDefinition` (parse/format) registry and built-in text/number/checkbox/date/select editors.
- Wire editing into `@gridsmith/react` Grid: double-click/F2/Enter/type-to-edit to open, Enter/Tab/Esc to commit or cancel, Delete/Backspace to clear, Tab/Shift+Tab to navigate between editable cells with row wrap, blur auto-commit, and `editable: false` for read-only columns.
- Ship custom editor API: column `cellEditor` renders a user-controlled React node that receives `{ value, row, rowIndex, column, commit, cancel }`.
- Closes retemper/gridsmith#5.

## Test plan

- [x] `pnpm turbo test --filter=@gridsmith/core` — 25 new editing plugin tests pass
- [x] `pnpm turbo test --filter=@gridsmith/react` — 35 Grid integration tests pass, coverage above 80% threshold
- [x] `pnpm turbo type-check lint`
- [x] `pnpm format:check`
- [x] Pre-push hook (turbo test --coverage with 80% global threshold) passes
- [ ] Manual smoke test in playground (editable text/number/select/checkbox/date columns, read-only column, F2/Enter/Tab/Esc keyboard flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)