### PR TITLE
feat(react): keyboard navigation and IME composition safety

### DIFF
--- a/.changeset/keyboard-nav-ime.md
+++ b/.changeset/keyboard-nav-ime.md
@@ -1,0 +1,5 @@
+---
+'@gridsmith/react': minor
+---
+
+Add full keyboard navigation (arrow keys, Tab/Shift+Tab wrap, Home/End, Ctrl+Home/End, Ctrl+Arrow edge jump, PageUp/PageDown), Shift+Enter to move up in nav mode, and Enter/Shift+Enter commit-and-move during editing. Focused cell exposes a `gs-cell--focused` CSS hook and scrolls into view on navigation. IME composition is respected — Enter/Tab no longer prematurely commit during Korean/Japanese/Chinese composition.

--- a/packages/react/src/cell-editor.tsx
+++ b/packages/react/src/cell-editor.tsx
@@ -1,7 +1,9 @@
 import type { CellValue, EditingPluginApi, GridInstance, SelectOption } from '@gridsmith/core';
 import {
   type CSSProperties,
+  type CompositionEvent,
   type KeyboardEvent,
+  type MutableRefObject,
   type ReactNode,
   memo,
   useCallback,
@@ -25,26 +27,70 @@ const EDITOR_INPUT_STYLE: CSSProperties = {
   background: 'var(--gs-editor-bg, #fff)',
 };
 
+/**
+ * Detect whether a keydown event occurred mid-IME composition.
+ *
+ * CJK IMEs (Korean/Japanese/Chinese) fire synthetic Enter/keydown events to
+ * commit composition. Without this guard, the editor would prematurely commit
+ * the cell on the final composition keystroke, dropping the composed character
+ * or trailing half-composed text. Belt-and-suspenders: check the standard
+ * `isComposing` flag, the legacy `keyCode === 229` sentinel, AND a ref
+ * driven by `compositionstart`/`compositionend` events.
+ */
+function isComposingEvent(
+  e: KeyboardEvent<HTMLElement>,
+  composingRef: MutableRefObject<boolean>,
+): boolean {
+  return composingRef.current || e.nativeEvent.isComposing || e.keyCode === 229;
+}
+
+interface EditorKeyCallbacks {
+  onCancel: () => void;
+  onTab: (shift: boolean) => void;
+  onEnter: (shift: boolean) => void;
+}
+
 function useEditorKeyHandler(
-  onCommit: () => void,
-  onCancel: () => void,
-  onTab: (shift: boolean) => void,
+  callbacks: EditorKeyCallbacks,
+  composingRef: MutableRefObject<boolean>,
 ) {
+  const { onCancel, onTab, onEnter } = callbacks;
   return useCallback(
     (e: KeyboardEvent<HTMLElement>) => {
+      // Ignore Enter/Tab while an IME composition is in-flight; the IME owns
+      // those keys for confirming candidate text. Escape still works so users
+      // can bail out.
       if (e.key === 'Enter') {
+        if (isComposingEvent(e, composingRef)) return;
         e.preventDefault();
-        onCommit();
+        onEnter(e.shiftKey);
       } else if (e.key === 'Escape') {
         e.preventDefault();
         onCancel();
       } else if (e.key === 'Tab') {
+        if (isComposingEvent(e, composingRef)) return;
         e.preventDefault();
         onTab(e.shiftKey);
       }
     },
-    [onCommit, onCancel, onTab],
+    [onCancel, onTab, onEnter, composingRef],
   );
+}
+
+function useCompositionHandlers(composingRef: MutableRefObject<boolean>) {
+  const onCompositionStart = useCallback(
+    (_e: CompositionEvent<HTMLElement>) => {
+      composingRef.current = true;
+    },
+    [composingRef],
+  );
+  const onCompositionEnd = useCallback(
+    (_e: CompositionEvent<HTMLElement>) => {
+      composingRef.current = false;
+    },
+    [composingRef],
+  );
+  return { onCompositionStart, onCompositionEnd };
 }
 
 // ─── Built-in editor inputs ─────────────────────────────────
@@ -55,11 +101,14 @@ interface InputEditorProps {
   onCommit: () => void;
   onCancel: () => void;
   onTab: (shift: boolean) => void;
+  onEnter: (shift: boolean) => void;
 }
 
-function TextEditor({ value, onChange, onCommit, onCancel, onTab }: InputEditorProps) {
+function TextEditor({ value, onChange, onCommit, onCancel, onTab, onEnter }: InputEditorProps) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const onKeyDown = useEditorKeyHandler(onCommit, onCancel, onTab);
+  const composingRef = useRef(false);
+  const onKeyDown = useEditorKeyHandler({ onCancel, onTab, onEnter }, composingRef);
+  const { onCompositionStart, onCompositionEnd } = useCompositionHandlers(composingRef);
 
   useEffect(() => {
     const el = inputRef.current;
@@ -76,15 +125,19 @@ function TextEditor({ value, onChange, onCommit, onCancel, onTab }: InputEditorP
       value={value}
       onChange={(e) => onChange(e.target.value)}
       onKeyDown={onKeyDown}
+      onCompositionStart={onCompositionStart}
+      onCompositionEnd={onCompositionEnd}
       onBlur={onCommit}
       style={EDITOR_INPUT_STYLE}
     />
   );
 }
 
-function NumberEditor({ value, onChange, onCommit, onCancel, onTab }: InputEditorProps) {
+function NumberEditor({ value, onChange, onCommit, onCancel, onTab, onEnter }: InputEditorProps) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const onKeyDown = useEditorKeyHandler(onCommit, onCancel, onTab);
+  const composingRef = useRef(false);
+  const onKeyDown = useEditorKeyHandler({ onCancel, onTab, onEnter }, composingRef);
+  const { onCompositionStart, onCompositionEnd } = useCompositionHandlers(composingRef);
 
   useEffect(() => {
     const el = inputRef.current;
@@ -102,6 +155,8 @@ function NumberEditor({ value, onChange, onCommit, onCancel, onTab }: InputEdito
       value={value}
       onChange={(e) => onChange(e.target.value)}
       onKeyDown={onKeyDown}
+      onCompositionStart={onCompositionStart}
+      onCompositionEnd={onCompositionEnd}
       onBlur={onCommit}
       style={EDITOR_INPUT_STYLE}
     />
@@ -112,9 +167,19 @@ interface SelectEditorProps extends InputEditorProps {
   options: SelectOption[];
 }
 
-function SelectEditor({ value, options, onChange, onCommit, onCancel, onTab }: SelectEditorProps) {
+function SelectEditor({
+  value,
+  options,
+  onChange,
+  onCommit,
+  onCancel,
+  onTab,
+  onEnter,
+}: SelectEditorProps) {
   const selectRef = useRef<HTMLSelectElement>(null);
-  const onKeyDown = useEditorKeyHandler(onCommit, onCancel, onTab);
+  // <select> has no IME composition path, so we hard-code a non-composing ref.
+  const nonComposingRef = useRef(false);
+  const onKeyDown = useEditorKeyHandler({ onCancel, onTab, onEnter }, nonComposingRef);
 
   useEffect(() => {
     selectRef.current?.focus();
@@ -145,9 +210,11 @@ function SelectEditor({ value, options, onChange, onCommit, onCancel, onTab }: S
   );
 }
 
-function DateEditor({ value, onChange, onCommit, onCancel, onTab }: InputEditorProps) {
+function DateEditor({ value, onChange, onCommit, onCancel, onTab, onEnter }: InputEditorProps) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const onKeyDown = useEditorKeyHandler(onCommit, onCancel, onTab);
+  // <input type="date"> is a native picker; no IME composition flows through it.
+  const nonComposingRef = useRef(false);
+  const onKeyDown = useEditorKeyHandler({ onCancel, onTab, onEnter }, nonComposingRef);
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -178,6 +245,11 @@ interface CellEditorOverlayProps {
   editValue: CellValue;
   columnId: string;
   style: CSSProperties;
+  /**
+   * Called after Enter commits the edit. The grid moves the focused cell
+   * vertically (without opening a new editor) to mirror Excel's Enter/Shift+Enter.
+   */
+  onCommitAndMoveVertical: (shift: boolean) => void;
 }
 
 export const CellEditorOverlay = memo(function CellEditorOverlay({
@@ -189,6 +261,7 @@ export const CellEditorOverlay = memo(function CellEditorOverlay({
   editValue,
   columnId,
   style,
+  onCommitAndMoveVertical,
 }: CellEditorOverlayProps) {
   const col = columns[columnIndex];
   const editorType = col?.editor ?? col?.type ?? 'text';
@@ -221,6 +294,13 @@ export const CellEditorOverlay = memo(function CellEditorOverlay({
   const handleCancel = useCallback(() => {
     editingApi.cancelEdit();
   }, [editingApi]);
+
+  const handleEnter = useCallback(
+    (shift: boolean) => {
+      onCommitAndMoveVertical(shift);
+    },
+    [onCommitAndMoveVertical],
+  );
 
   const handleTab = useCallback(
     (shift: boolean) => {
@@ -303,6 +383,7 @@ export const CellEditorOverlay = memo(function CellEditorOverlay({
         onCommit={handleCommit}
         onCancel={handleCancel}
         onTab={handleTab}
+        onEnter={handleEnter}
       />
     );
   } else if (editorType === 'date') {
@@ -313,6 +394,7 @@ export const CellEditorOverlay = memo(function CellEditorOverlay({
         onCommit={handleCommit}
         onCancel={handleCancel}
         onTab={handleTab}
+        onEnter={handleEnter}
       />
     );
   } else if (editorType === 'number') {
@@ -323,6 +405,7 @@ export const CellEditorOverlay = memo(function CellEditorOverlay({
         onCommit={handleCommit}
         onCancel={handleCancel}
         onTab={handleTab}
+        onEnter={handleEnter}
       />
     );
   } else {
@@ -333,6 +416,7 @@ export const CellEditorOverlay = memo(function CellEditorOverlay({
         onCommit={handleCommit}
         onCancel={handleCancel}
         onTab={handleTab}
+        onEnter={handleEnter}
       />
     );
   }

--- a/packages/react/src/grid.tsx
+++ b/packages/react/src/grid.tsx
@@ -61,6 +61,23 @@ function isPrintableKey(e: KeyboardEvent): boolean {
   return e.key.length === 1;
 }
 
+/**
+ * Navigation key set handled by the grid root when no editor is active. When
+ * the key matches, the grid owns it (preventDefault + focus update); otherwise
+ * the key falls through to existing editing-entry handling (F2, Enter, etc.).
+ */
+const NAV_KEYS: ReadonlySet<string> = new Set([
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'Home',
+  'End',
+  'PageUp',
+  'PageDown',
+  'Tab',
+]);
+
 export const Grid = memo(function Grid({
   data,
   columns,
@@ -345,6 +362,13 @@ export const Grid = memo(function Grid({
           if (dec.attributes) Object.assign(attrs, dec.attributes);
         }
 
+        // Keyboard focus indicator — purely visual, consumers can restyle via
+        // `.gs-cell--focused`. Not a core decoration because focus is an
+        // adapter-level concern tied to the Grid component's React state.
+        if (focusedCell && focusedCell.row === r && focusedCell.col === col.id) {
+          cellClassName += ' gs-cell--focused';
+        }
+
         cells.push(
           <div
             key={col.id}
@@ -377,7 +401,17 @@ export const Grid = memo(function Grid({
     }
 
     return result;
-  }, [visibleRange, totalRows, columns, grid, columnLayout, columnIds, rowHeight, dataVersion]);
+  }, [
+    visibleRange,
+    totalRows,
+    columns,
+    grid,
+    columnLayout,
+    columnIds,
+    rowHeight,
+    dataVersion,
+    focusedCell,
+  ]);
 
   // ─── Cell interaction handlers ──────────────────────────
 
@@ -440,12 +474,177 @@ export const Grid = memo(function Grid({
     [parseCellFromTarget, editState, editingApi, currentColumns, grid],
   );
 
+  // ─── Navigation helpers ────────────────────────────────
+
+  /** Ordered list of visible column indices. Hidden columns are skipped
+   *  during navigation so arrow keys never land on an invisible cell. */
+  const visibleColIndices = useMemo(() => {
+    const out: number[] = [];
+    for (let i = 0; i < currentColumns.length; i++) {
+      if (currentColumns[i].visible !== false) out.push(i);
+    }
+    return out;
+  }, [currentColumns]);
+
+  const scrollFocusIntoView = useCallback(
+    (row: number, colIndex: number) => {
+      const el = viewportRef.current;
+      if (!el) return;
+      const cellTop = row * rowHeight;
+      const cellBottom = cellTop + rowHeight;
+      const cellLeft = columnLayout.offsets[colIndex] ?? 0;
+      const cellRight = cellLeft + (columnLayout.widths[colIndex] ?? 0);
+
+      if (cellTop < el.scrollTop) el.scrollTop = cellTop;
+      else if (cellBottom > el.scrollTop + el.clientHeight) {
+        el.scrollTop = cellBottom - el.clientHeight;
+      }
+
+      if (cellLeft < el.scrollLeft) el.scrollLeft = cellLeft;
+      else if (cellRight > el.scrollLeft + el.clientWidth) {
+        el.scrollLeft = cellRight - el.clientWidth;
+      }
+    },
+    [columnLayout, rowHeight],
+  );
+
+  const moveFocusTo = useCallback(
+    (row: number, colIndex: number) => {
+      if (totalRows === 0 || visibleColIndices.length === 0) return;
+      const clampedRow = Math.max(0, Math.min(totalRows - 1, row));
+      // colIndex must be one of the visible indices — callers compute from
+      // `visibleColIndices`, but clamp defensively.
+      const clampedCol =
+        visibleColIndices.indexOf(colIndex) === -1 ? (visibleColIndices[0] ?? 0) : colIndex;
+      const col = currentColumns[clampedCol];
+      if (!col) return;
+      setFocusedCell({ row: clampedRow, col: col.id, colIndex: clampedCol });
+      scrollFocusIntoView(clampedRow, clampedCol);
+    },
+    [totalRows, visibleColIndices, currentColumns, scrollFocusIntoView],
+  );
+
+  /**
+   * Return the visible column index one step left/right of the given one.
+   * If no such column exists, return `null` (caller decides whether to wrap
+   * to another row).
+   */
+  const stepVisibleCol = useCallback(
+    (colIndex: number, delta: 1 | -1): number | null => {
+      const pos = visibleColIndices.indexOf(colIndex);
+      if (pos === -1) return null;
+      const next = pos + delta;
+      if (next < 0 || next >= visibleColIndices.length) return null;
+      return visibleColIndices[next];
+    },
+    [visibleColIndices],
+  );
+
+  const firstVisibleColIndex = visibleColIndices[0] ?? 0;
+  const lastVisibleColIndex = visibleColIndices[visibleColIndices.length - 1] ?? 0;
+
+  const handleCommitAndMoveVertical = useCallback(
+    (shift: boolean) => {
+      // Resolve the *edited* cell, not `focusedCell` — Tab inside the editor
+      // advances `editState` without touching `focusedCell`, so the two can
+      // diverge. Using the edit target keeps Enter's "move down" relative to
+      // the cell the user was actually editing.
+      const state = editingApi.getEditState();
+      editingApi.commitEdit();
+      if (!state) return;
+      const colIndex = currentColumns.findIndex((c) => c.id === state.columnId);
+      if (colIndex === -1) return;
+      const delta = shift ? -1 : 1;
+      moveFocusTo(state.rowIndex + delta, colIndex);
+    },
+    [editingApi, currentColumns, moveFocusTo],
+  );
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       // If currently editing, the editor handles its own keys
       if (editState) return;
 
       if (!focusedCell) return;
+
+      const { row, colIndex } = focusedCell;
+      const lastRow = totalRows - 1;
+      const mod = e.ctrlKey || e.metaKey;
+
+      // ─── Pure navigation keys ────────────────────────
+      if (NAV_KEYS.has(e.key)) {
+        e.preventDefault();
+        switch (e.key) {
+          case 'ArrowUp': {
+            moveFocusTo(mod ? 0 : row - 1, colIndex);
+            return;
+          }
+          case 'ArrowDown': {
+            moveFocusTo(mod ? lastRow : row + 1, colIndex);
+            return;
+          }
+          case 'ArrowLeft': {
+            if (mod) {
+              moveFocusTo(row, firstVisibleColIndex);
+            } else {
+              const next = stepVisibleCol(colIndex, -1);
+              if (next !== null) moveFocusTo(row, next);
+            }
+            return;
+          }
+          case 'ArrowRight': {
+            if (mod) {
+              moveFocusTo(row, lastVisibleColIndex);
+            } else {
+              const next = stepVisibleCol(colIndex, 1);
+              if (next !== null) moveFocusTo(row, next);
+            }
+            return;
+          }
+          case 'Home': {
+            moveFocusTo(mod ? 0 : row, firstVisibleColIndex);
+            return;
+          }
+          case 'End': {
+            moveFocusTo(mod ? lastRow : row, lastVisibleColIndex);
+            return;
+          }
+          case 'PageDown': {
+            const el = viewportRef.current;
+            const pageSize = el ? Math.max(1, Math.floor(el.clientHeight / rowHeight)) : 1;
+            moveFocusTo(row + pageSize, colIndex);
+            return;
+          }
+          case 'PageUp': {
+            const el = viewportRef.current;
+            const pageSize = el ? Math.max(1, Math.floor(el.clientHeight / rowHeight)) : 1;
+            moveFocusTo(row - pageSize, colIndex);
+            return;
+          }
+          case 'Tab': {
+            // Tab wraps within the row; at boundaries it moves to the next/
+            // previous row's last/first cell.
+            if (e.shiftKey) {
+              const prev = stepVisibleCol(colIndex, -1);
+              if (prev !== null) moveFocusTo(row, prev);
+              else if (row > 0) moveFocusTo(row - 1, lastVisibleColIndex);
+            } else {
+              const next = stepVisibleCol(colIndex, 1);
+              if (next !== null) moveFocusTo(row, next);
+              else if (row < lastRow) moveFocusTo(row + 1, firstVisibleColIndex);
+            }
+            return;
+          }
+        }
+      }
+
+      // Shift+Enter in nav mode = move up (Enter without shift preserves the
+      // "begin edit" behavior users expect from the current grid).
+      if (e.key === 'Enter' && e.shiftKey) {
+        e.preventDefault();
+        moveFocusTo(row - 1, colIndex);
+        return;
+      }
 
       if (e.key === 'F2') {
         e.preventDefault();
@@ -492,7 +691,19 @@ export const Grid = memo(function Grid({
         }
       }
     },
-    [editState, focusedCell, currentColumns, editingApi, grid],
+    [
+      editState,
+      focusedCell,
+      totalRows,
+      currentColumns,
+      editingApi,
+      grid,
+      moveFocusTo,
+      stepVisibleCol,
+      firstVisibleColIndex,
+      lastVisibleColIndex,
+      rowHeight,
+    ],
   );
 
   // ─── Editor overlay ───────────────────────────────────
@@ -527,9 +738,19 @@ export const Grid = memo(function Grid({
         editValue={editState.value}
         columnId={editState.columnId}
         style={editorStyle}
+        onCommitAndMoveVertical={handleCommitAndMoveVertical}
       />
     );
-  }, [editState, currentColumns, columnLayout, rowHeight, grid, editingApi, columns]);
+  }, [
+    editState,
+    currentColumns,
+    columnLayout,
+    rowHeight,
+    grid,
+    editingApi,
+    columns,
+    handleCommitAndMoveVertical,
+  ]);
 
   // ─── JSX ───────────────────────────────────────────────
 

--- a/packages/react/src/keyboard-nav.spec.tsx
+++ b/packages/react/src/keyboard-nav.spec.tsx
@@ -1,0 +1,424 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import { Grid } from './grid';
+import type { GridColumnDef } from './types';
+
+// ─── DOM mocks ────────────────────────────────────────────
+//
+// jsdom reports clientWidth/clientHeight as 0 by default. The Grid needs a
+// non-zero viewport to compute visible ranges and page sizes. These mocks
+// match the scheme used in the sibling spec files.
+
+const origCW = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+const origCH = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+
+beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    get() {
+      return 500;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    get() {
+      return 300;
+    },
+  });
+
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+afterEach(() => {
+  if (origCW) Object.defineProperty(HTMLElement.prototype, 'clientWidth', origCW);
+  if (origCH) Object.defineProperty(HTMLElement.prototype, 'clientHeight', origCH);
+  vi.restoreAllMocks();
+});
+
+// ─── Fixtures ─────────────────────────────────────────────
+
+const columns: GridColumnDef[] = [
+  { id: 'a', header: 'A', type: 'text' },
+  { id: 'b', header: 'B', type: 'text' },
+  { id: 'c', header: 'C', type: 'text' },
+];
+
+const data = [
+  { a: 'a0', b: 'b0', c: 'c0' },
+  { a: 'a1', b: 'b1', c: 'c1' },
+  { a: 'a2', b: 'b2', c: 'c2' },
+];
+
+function findCell(row: number, col: string): HTMLElement {
+  const el = document.querySelector(`[data-row="${row}"][data-col="${col}"]`);
+  if (!el) throw new Error(`cell (${row}, ${col}) not found`);
+  return el as HTMLElement;
+}
+
+function getGridRoot(): HTMLElement {
+  const root = document.querySelector('.gs-grid');
+  if (!root) throw new Error('Grid root not found');
+  return root as HTMLElement;
+}
+
+function focusedCellPos(): { row: string | null; col: string | null } {
+  const el = document.querySelector('.gs-cell--focused') as HTMLElement | null;
+  return {
+    row: el?.dataset.row ?? null,
+    col: el?.dataset.col ?? null,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────
+
+describe('keyboard navigation — arrow keys', () => {
+  it('applies gs-cell--focused class on click', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(1, 'b'));
+    expect(focusedCellPos()).toEqual({ row: '1', col: 'b' });
+  });
+
+  it('ArrowDown moves focus down one row', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(0, 'a'));
+    fireEvent.keyDown(getGridRoot(), { key: 'ArrowDown' });
+    expect(focusedCellPos()).toEqual({ row: '1', col: 'a' });
+  });
+
+  it('ArrowDown is clamped at the last row', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(2, 'a'));
+    fireEvent.keyDown(getGridRoot(), { key: 'ArrowDown' });
+    expect(focusedCellPos()).toEqual({ row: '2', col: 'a' });
+  });
+
+  it('ArrowUp moves focus up one row', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(2, 'b'));
+    fireEvent.keyDown(getGridRoot(), { key: 'ArrowUp' });
+    expect(focusedCellPos()).toEqual({ row: '1', col: 'b' });
+  });
+
+  it('ArrowUp is clamped at row 0', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(0, 'a'));
+    fireEvent.keyDown(getGridRoot(), { key: 'ArrowUp' });
+    expect(focusedCellPos()).toEqual({ row: '0', col: 'a' });
+  });
+
+  it('ArrowRight moves focus to next column', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(1, 'a'));
+    fireEvent.keyDown(getGridRoot(), { key: 'ArrowRight' });
+    expect(focusedCellPos()).toEqual({ row: '1', col: 'b' });
+  });
+
+  it('ArrowRight does not move past the last column', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(1, 'c'));
+    fireEvent.keyDown(getGridRoot(), { key: 'ArrowRight' });
+    expect(focusedCellPos()).toEqual({ row: '1', col: 'c' });
+  });
+
+  it('ArrowLeft moves focus to previous column', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(1, 'c'));
+    fireEvent.keyDown(getGridRoot(), { key: 'ArrowLeft' });
+    expect(focusedCellPos()).toEqual({ row: '1', col: 'b' });
+  });
+
+  it('ArrowLeft does not move past the first column', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(1, 'a'));
+    fireEvent.keyDown(getGridRoot(), { key: 'ArrowLeft' });
+    expect(focusedCellPos()).toEqual({ row: '1', col: 'a' });
+  });
+
+  it('ArrowRight skips hidden columns', () => {
+    const cols: GridColumnDef[] = [
+      { id: 'a', header: 'A' },
+      { id: 'b', header: 'B', visible: false },
+      { id: 'c', header: 'C' },
+    ];
+    const rows = [{ a: '0', b: '1', c: '2' }];
+    render(<Grid data={rows} columns={cols} />);
+    fireEvent.click(findCell(0, 'a'));
+    fireEvent.keyDown(getGridRoot(), { key: 'ArrowRight' });
+    expect(focusedCellPos()).toEqual({ row: '0', col: 'c' });
+  });
+});
+
+describe('keyboard navigation — Ctrl jumps', () => {
+  it('Ctrl+ArrowDown jumps to the last row', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(0, 'b'));
+    fireEvent.keyDown(getGridRoot(), { key: 'ArrowDown', ctrlKey: true });
+    expect(focusedCellPos()).toEqual({ row: '2', col: 'b' });
+  });
+
+  it('Ctrl+ArrowUp jumps to the first row', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(2, 'b'));
+    fireEvent.keyDown(getGridRoot(), { key: 'ArrowUp', ctrlKey: true });
+    expect(focusedCellPos()).toEqual({ row: '0', col: 'b' });
+  });
+
+  it('Ctrl+ArrowRight jumps to the last column', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(1, 'a'));
+    fireEvent.keyDown(getGridRoot(), { key: 'ArrowRight', ctrlKey: true });
+    expect(focusedCellPos()).toEqual({ row: '1', col: 'c' });
+  });
+
+  it('Ctrl+ArrowLeft jumps to the first column', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(1, 'c'));
+    fireEvent.keyDown(getGridRoot(), { key: 'ArrowLeft', ctrlKey: true });
+    expect(focusedCellPos()).toEqual({ row: '1', col: 'a' });
+  });
+
+  it('metaKey (Cmd on macOS) works like Ctrl', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(0, 'b'));
+    fireEvent.keyDown(getGridRoot(), { key: 'ArrowDown', metaKey: true });
+    expect(focusedCellPos()).toEqual({ row: '2', col: 'b' });
+  });
+});
+
+describe('keyboard navigation — Home/End/PageUp/PageDown', () => {
+  it('Home moves to first column of current row', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(1, 'c'));
+    fireEvent.keyDown(getGridRoot(), { key: 'Home' });
+    expect(focusedCellPos()).toEqual({ row: '1', col: 'a' });
+  });
+
+  it('End moves to last column of current row', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(1, 'a'));
+    fireEvent.keyDown(getGridRoot(), { key: 'End' });
+    expect(focusedCellPos()).toEqual({ row: '1', col: 'c' });
+  });
+
+  it('Ctrl+Home moves to the first cell (0,0)', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(2, 'c'));
+    fireEvent.keyDown(getGridRoot(), { key: 'Home', ctrlKey: true });
+    expect(focusedCellPos()).toEqual({ row: '0', col: 'a' });
+  });
+
+  it('Ctrl+End moves to the last cell', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(0, 'a'));
+    fireEvent.keyDown(getGridRoot(), { key: 'End', ctrlKey: true });
+    expect(focusedCellPos()).toEqual({ row: '2', col: 'c' });
+  });
+
+  it('PageDown jumps by viewport-sized row chunks', () => {
+    // 20 rows × default rowHeight 32 = 640px; viewport clientHeight mocked to
+    // 300 → page size = floor(300/32) = 9.
+    const many = Array.from({ length: 20 }, (_, i) => ({
+      a: `a${i}`,
+      b: `b${i}`,
+      c: `c${i}`,
+    }));
+    render(<Grid data={many} columns={columns} />);
+    fireEvent.click(findCell(0, 'a'));
+    fireEvent.keyDown(getGridRoot(), { key: 'PageDown' });
+    expect(focusedCellPos().row).toBe('9');
+  });
+
+  it('PageUp jumps backwards by viewport-sized chunks and clamps at 0', () => {
+    const many = Array.from({ length: 20 }, (_, i) => ({
+      a: `a${i}`,
+      b: `b${i}`,
+      c: `c${i}`,
+    }));
+    render(<Grid data={many} columns={columns} />);
+    fireEvent.click(findCell(5, 'a'));
+    fireEvent.keyDown(getGridRoot(), { key: 'PageUp' });
+    expect(focusedCellPos().row).toBe('0');
+  });
+});
+
+describe('keyboard navigation — Tab/Shift+Tab in nav mode', () => {
+  it('Tab moves focus right in nav mode', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(0, 'a'));
+    fireEvent.keyDown(getGridRoot(), { key: 'Tab' });
+    expect(focusedCellPos()).toEqual({ row: '0', col: 'b' });
+  });
+
+  it('Tab wraps to next row at end of row', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(0, 'c'));
+    fireEvent.keyDown(getGridRoot(), { key: 'Tab' });
+    expect(focusedCellPos()).toEqual({ row: '1', col: 'a' });
+  });
+
+  it('Shift+Tab moves focus left and wraps to previous row at start', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(1, 'a'));
+    fireEvent.keyDown(getGridRoot(), { key: 'Tab', shiftKey: true });
+    expect(focusedCellPos()).toEqual({ row: '0', col: 'c' });
+  });
+
+  it('Shift+Enter moves focus up in nav mode', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.click(findCell(2, 'b'));
+    fireEvent.keyDown(getGridRoot(), { key: 'Enter', shiftKey: true });
+    expect(focusedCellPos()).toEqual({ row: '1', col: 'b' });
+  });
+});
+
+describe('keyboard navigation — edit mode', () => {
+  it('Enter during editing commits and moves focus down', () => {
+    const onCellChange = vi.fn();
+    render(<Grid data={data} columns={columns} onCellChange={onCellChange} />);
+
+    fireEvent.doubleClick(findCell(0, 'a'));
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'changed' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onCellChange).toHaveBeenCalledWith(
+      expect.objectContaining({ col: 'a', newValue: 'changed' }),
+    );
+    // Editor closed; focus moved down; no new editor opened.
+    expect(document.querySelector('.gs-cell-editor')).toBeNull();
+    expect(focusedCellPos()).toEqual({ row: '1', col: 'a' });
+  });
+
+  it('Shift+Enter during editing commits and moves focus up', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.doubleClick(findCell(1, 'b'));
+
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true });
+
+    expect(document.querySelector('.gs-cell-editor')).toBeNull();
+    expect(focusedCellPos()).toEqual({ row: '0', col: 'b' });
+  });
+
+  it('Enter during editing at last row stays at last row', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.doubleClick(findCell(2, 'a'));
+
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(focusedCellPos()).toEqual({ row: '2', col: 'a' });
+  });
+
+  it('Enter after Tab inside editor moves down from the *edited* cell, not the clicked one', () => {
+    // Regression: handleCommitAndMoveVertical must read editState (current
+    // edit target) rather than focusedCell (stuck at the original click),
+    // otherwise Tab-then-Enter jumps back to the wrong column.
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.doubleClick(findCell(0, 'a'));
+
+    // Tab from (0,a) to (0,b) inside the editor (focusedCell stays at (0,a))
+    fireEvent.keyDown(document.querySelector('.gs-cell-editor input') as HTMLInputElement, {
+      key: 'Tab',
+    });
+
+    // Editor moved to 'b'; now Enter should commit from (0,b) and move to (1,b)
+    fireEvent.keyDown(document.querySelector('.gs-cell-editor input') as HTMLInputElement, {
+      key: 'Enter',
+    });
+
+    expect(focusedCellPos()).toEqual({ row: '1', col: 'b' });
+  });
+});
+
+describe('IME composition safety', () => {
+  it('Enter during composition does NOT commit the edit', () => {
+    const onCellChange = vi.fn();
+    render(<Grid data={data} columns={columns} onCellChange={onCellChange} />);
+
+    fireEvent.doubleClick(findCell(0, 'a'));
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+
+    // Start composition (e.g. Korean IME opening)
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: '한' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    // Editor still open; no commit fired
+    expect(document.querySelector('.gs-cell-editor')).toBeTruthy();
+    expect(onCellChange).not.toHaveBeenCalled();
+  });
+
+  it('Enter after composition ends commits normally', () => {
+    const onCellChange = vi.fn();
+    render(<Grid data={data} columns={columns} onCellChange={onCellChange} />);
+
+    fireEvent.doubleClick(findCell(0, 'a'));
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: '한' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    fireEvent.compositionEnd(input);
+
+    // Second Enter (after composition ended) should commit.
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onCellChange).toHaveBeenCalledWith(
+      expect.objectContaining({ col: 'a', newValue: '한' }),
+    );
+  });
+
+  it('Tab during composition does NOT commit/move', () => {
+    render(<Grid data={data} columns={columns} />);
+    fireEvent.doubleClick(findCell(0, 'a'));
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+
+    fireEvent.compositionStart(input);
+    fireEvent.keyDown(input, { key: 'Tab' });
+
+    // Still editing the same (row, col); editor hasn't moved.
+    const stillEditing = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    expect(stillEditing).toBeTruthy();
+    // Confirm the editor is at (0, 'a') — value should still reflect original.
+    expect(stillEditing.value).toBe('a0');
+  });
+
+  it('keyCode 229 (legacy IME sentinel) suppresses commit even without compositionstart', () => {
+    const onCellChange = vi.fn();
+    render(<Grid data={data} columns={columns} onCellChange={onCellChange} />);
+
+    fireEvent.doubleClick(findCell(0, 'a'));
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+
+    // Some legacy browsers only set keyCode=229 during composition without
+    // populating isComposing. Simulate that case directly.
+    fireEvent.keyDown(input, { key: 'Enter', keyCode: 229 });
+
+    expect(onCellChange).not.toHaveBeenCalled();
+    expect(document.querySelector('.gs-cell-editor')).toBeTruthy();
+  });
+
+  it('Escape during composition still cancels the editor', () => {
+    // IME users must have a way to abort; Escape should always work.
+    const onCellChange = vi.fn();
+    render(<Grid data={data} columns={columns} onCellChange={onCellChange} />);
+
+    fireEvent.doubleClick(findCell(0, 'a'));
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+
+    fireEvent.compositionStart(input);
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(document.querySelector('.gs-cell-editor')).toBeNull();
+    expect(onCellChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Full keyboard navigation: arrows, Tab/Shift+Tab (wraps across rows), Home/End, Ctrl+Home/End, Ctrl+Arrow edge-jump, PageUp/PageDown, Shift+Enter to move up in nav mode, and Enter/Shift+Enter commit-and-move during editing.
- Focused cell gets a `gs-cell--focused` CSS hook and auto-scrolls into view on navigation.
- IME composition safety: Enter/Tab no longer prematurely commit during Korean/Japanese/Chinese composition — guarded by `nativeEvent.isComposing`, legacy `keyCode === 229`, and a `compositionstart`/`compositionend` ref.

Closes #6

## Test plan

- [x] 34 new tests in `keyboard-nav.spec.tsx` (arrows, Ctrl jumps, Home/End, PageUp/Down, Tab wrap, Shift+Enter nav, Enter commit-and-move, IME guards, keyCode 229 fallback, Escape during composition)
- [x] Regression test: Tab inside editor → Enter commits from the *edited* cell, not the originally focused one
- [x] `pnpm turbo test lint type-check` (98/98 passing)
- [x] `pnpm format:check`
- [ ] Manual check: type Korean/Japanese into a cell, confirm Enter doesn't prematurely commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)