### PR TITLE
feat: excel-compatible clipboard — TSV + HTML (#11)

### DIFF
--- a/.changeset/excel-clipboard.md
+++ b/.changeset/excel-clipboard.md
@@ -1,0 +1,40 @@
+---
+'@gridsmith/core': minor
+'@gridsmith/react': minor
+---
+
+Add Excel-compatible clipboard: TSV + HTML copy, paste, cut, delete.
+
+**Core (`@gridsmith/core`):**
+
+- New `createClipboardPlugin` exports a `'clipboard'` plugin that depends
+  on `'selection'` and round-trips cell values with Excel and Google
+  Sheets.
+- New types: `ClipboardPayload`, `ClipboardMatrix`, `ClipboardPluginApi`.
+  The API exposes `copy`, `cut`, `paste`, `deleteSelection`,
+  `serializeRange`, `parsePayload`, and `applyMatrix` for programmatic
+  use.
+- Copy writes both `text/plain` (TSV) and `text/html` (minimal `<table>`)
+  via the modern `ClipboardItem` API, with a `writeText` fallback when
+  rich writes are unavailable or denied.
+- Paste prefers parsed HTML tables and falls back to TSV; multi-line
+  quoted cells and Excel's trailing CRLF are handled transparently.
+- Values are formatted for Excel compatibility: booleans as `TRUE`/`FALSE`,
+  dates as `YYYY-MM-DD`, `null`/`undefined` as empty string. Paste coerces
+  strings back to the target column's declared type (`number`, `checkbox`,
+  `date`) and leaves unrecognized input as raw text.
+- `deleteSelection` clears every editable cell across all ranges, skips
+  `editable: false` columns, and batches changes in a single update.
+- New grid events: `clipboard:copy`, `clipboard:cut`, `clipboard:paste`.
+
+**React (`@gridsmith/react`):**
+
+- Auto-registers the clipboard plugin alongside editing and selection.
+- Keyboard parity with Excel: Ctrl/Cmd+C copies the active range,
+  Ctrl/Cmd+X cuts, Ctrl/Cmd+V pastes at the active cell, and
+  Delete/Backspace clears every selected cell (falling back to the
+  focused cell when there is no range selection).
+- Sibling text inputs (e.g. filter popovers) keep native clipboard
+  behavior — the grid only intercepts when focus is on the grid itself.
+- New `useGridClipboard(grid)` hook exposes the clipboard API for
+  programmatic copy/cut/paste in custom toolbars.

--- a/packages/core/src/clipboard.spec.ts
+++ b/packages/core/src/clipboard.spec.ts
@@ -1,0 +1,440 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createClipboardPlugin } from './clipboard';
+import { createGrid } from './grid';
+import { createSelectionPlugin } from './selection';
+import type { CellRange, ClipboardPluginApi, ColumnDef, Row, SelectionPluginApi } from './types';
+
+const columns: ColumnDef[] = [
+  { id: 'a', header: 'A', type: 'text' },
+  { id: 'b', header: 'B', type: 'number' },
+  { id: 'c', header: 'C', type: 'checkbox' },
+  { id: 'd', header: 'D', type: 'text' },
+];
+
+const initialData: Row[] = [
+  { a: 'a0', b: 10, c: true, d: 'd0' },
+  { a: 'a1', b: 20, c: false, d: 'd1' },
+  { a: 'a2', b: 30, c: true, d: 'd2' },
+  { a: 'a3', b: 40, c: false, d: 'd3' },
+];
+
+function setup(overrides: { data?: Row[]; columns?: ColumnDef[] } = {}): {
+  grid: ReturnType<typeof createGrid>;
+  selection: SelectionPluginApi;
+  clipboard: ClipboardPluginApi;
+} {
+  const grid = createGrid({
+    data: overrides.data ?? initialData,
+    columns: overrides.columns ?? columns,
+    plugins: [createSelectionPlugin(), createClipboardPlugin()],
+  });
+  return {
+    grid,
+    selection: grid.getPlugin<SelectionPluginApi>('selection')!,
+    clipboard: grid.getPlugin<ClipboardPluginApi>('clipboard')!,
+  };
+}
+
+function range(startRow: number, endRow: number, startCol: string, endCol: string): CellRange {
+  return { startRow, endRow, startCol, endCol };
+}
+
+describe('clipboard plugin', () => {
+  describe('serializeRange', () => {
+    it('emits TSV matching Excel output for a simple range', () => {
+      const { clipboard } = setup();
+      const payload = clipboard.serializeRange(range(0, 1, 'a', 'b'));
+      expect(payload.text).toBe('a0\t10\na1\t20');
+    });
+
+    it('emits HTML with one <tr> per row and one <td> per cell', () => {
+      const { clipboard } = setup();
+      const { html } = clipboard.serializeRange(range(0, 1, 'a', 'b'));
+      expect(html).toContain('<table>');
+      expect(html).toContain('<tr><td>a0</td><td>10</td></tr>');
+      expect(html).toContain('<tr><td>a1</td><td>20</td></tr>');
+    });
+
+    it('formats booleans as TRUE/FALSE to match Excel', () => {
+      const { clipboard } = setup();
+      const { text } = clipboard.serializeRange(range(0, 1, 'c', 'c'));
+      expect(text).toBe('TRUE\nFALSE');
+    });
+
+    it('formats dates as YYYY-MM-DD', () => {
+      const { clipboard } = setup({
+        data: [{ a: new Date(2026, 0, 5) }],
+        columns: [{ id: 'a', header: 'A', type: 'date' }],
+      });
+      const { text } = clipboard.serializeRange(range(0, 0, 'a', 'a'));
+      expect(text).toBe('2026-01-05');
+    });
+
+    it('quotes cells containing tabs, newlines, or double-quotes', () => {
+      const { clipboard } = setup({
+        data: [
+          { a: 'has\ttab', b: 'line1\nline2' },
+          { a: 'quote"inside', b: 'plain' },
+        ],
+        columns: [
+          { id: 'a', header: 'A', type: 'text' },
+          { id: 'b', header: 'B', type: 'text' },
+        ],
+      });
+      const { text } = clipboard.serializeRange(range(0, 1, 'a', 'b'));
+      expect(text).toContain('"has\ttab"');
+      expect(text).toContain('"line1\nline2"');
+      expect(text).toContain('"quote""inside"');
+      expect(text).toContain('plain');
+    });
+
+    it('renders null/undefined as empty string', () => {
+      const { clipboard } = setup({
+        data: [{ a: null, b: undefined }],
+        columns: [
+          { id: 'a', header: 'A', type: 'text' },
+          { id: 'b', header: 'B', type: 'text' },
+        ],
+      });
+      const { text } = clipboard.serializeRange(range(0, 0, 'a', 'b'));
+      expect(text).toBe('\t');
+    });
+  });
+
+  describe('parsePayload', () => {
+    it('parses plain TSV into a string matrix', () => {
+      const { clipboard } = setup();
+      const parsed = clipboard.parsePayload({ text: 'x\ty\nz\tw' });
+      expect(parsed).toEqual([
+        ['x', 'y'],
+        ['z', 'w'],
+      ]);
+    });
+
+    it('drops a trailing empty row (Excel appends CRLF)', () => {
+      const { clipboard } = setup();
+      const parsed = clipboard.parsePayload({ text: 'x\ty\r\n' });
+      expect(parsed).toEqual([['x', 'y']]);
+    });
+
+    it('parses quoted cells with embedded tabs, newlines, and doubled quotes', () => {
+      const { clipboard } = setup();
+      const parsed = clipboard.parsePayload({
+        text: '"a\tb"\t"line1\nline2"\n"he said ""hi"""\tplain',
+      });
+      expect(parsed).toEqual([
+        ['a\tb', 'line1\nline2'],
+        ['he said "hi"', 'plain'],
+      ]);
+    });
+
+    it('prefers HTML table when present', () => {
+      const { clipboard } = setup();
+      const parsed = clipboard.parsePayload({
+        text: 'ignored',
+        html: '<table><tr><td>html1</td><td>html2</td></tr></table>',
+      });
+      expect(parsed).toEqual([['html1', 'html2']]);
+    });
+
+    it('falls back to TSV when HTML has no table', () => {
+      const { clipboard } = setup();
+      const parsed = clipboard.parsePayload({
+        text: 'a\tb',
+        html: '<div>not a table</div>',
+      });
+      expect(parsed).toEqual([['a', 'b']]);
+    });
+
+    it('falls back to TSV when HTML table has no rows', () => {
+      const { clipboard } = setup();
+      const parsed = clipboard.parsePayload({
+        text: 'a\tb',
+        html: '<table></table>',
+      });
+      expect(parsed).toEqual([['a', 'b']]);
+    });
+
+    it('returns null for empty input', () => {
+      const { clipboard } = setup();
+      expect(clipboard.parsePayload({})).toBeNull();
+      expect(clipboard.parsePayload({ text: '' })).toBeNull();
+    });
+  });
+
+  describe('applyMatrix', () => {
+    it('writes values starting at (row, col) and stops at the right edge', () => {
+      const { clipboard, grid } = setup();
+      clipboard.applyMatrix(
+        [
+          ['x', 'y'],
+          ['z', 'w'],
+        ],
+        1,
+        'c',
+      );
+      expect(grid.getCell(1, 'c')).toBe('x'); // text coerce for type='checkbox' -> string fallback
+      expect(grid.getCell(1, 'd')).toBe('y');
+      expect(grid.getCell(2, 'c')).toBe('z');
+      expect(grid.getCell(2, 'd')).toBe('w');
+    });
+
+    it('coerces strings to the target column type on paste', () => {
+      const { clipboard, grid } = setup();
+      clipboard.applyMatrix([['42', 'TRUE']], 0, 'b');
+      expect(grid.getCell(0, 'b')).toBe(42);
+      expect(grid.getCell(0, 'c')).toBe(true);
+    });
+
+    it('parses dates back to Date objects in date columns', () => {
+      const { clipboard, grid } = setup({
+        data: [{ a: null }],
+        columns: [{ id: 'a', header: 'A', type: 'date' }],
+      });
+      clipboard.applyMatrix([['2026-04-18']], 0, 'a');
+      const value = grid.getCell(0, 'a');
+      expect(value).toBeInstanceOf(Date);
+      expect((value as Date).getFullYear()).toBe(2026);
+    });
+
+    it('treats empty string as null', () => {
+      const { clipboard, grid } = setup();
+      clipboard.applyMatrix([['']], 0, 'a');
+      expect(grid.getCell(0, 'a')).toBeNull();
+    });
+
+    it('skips cells that fall outside the grid bounds', () => {
+      const { clipboard, grid } = setup();
+      clipboard.applyMatrix([['keep', 'skip']], 3, 'd');
+      expect(grid.getCell(3, 'd')).toBe('keep');
+      // No row 4, so second cell has nowhere to land — grid only has rows 0..3.
+      expect(grid.rowCount).toBe(4);
+    });
+
+    it('skips non-editable columns', () => {
+      const { clipboard, grid } = setup({
+        columns: [
+          { id: 'a', header: 'A', type: 'text' },
+          { id: 'b', header: 'B', type: 'text', editable: false },
+        ],
+        data: [{ a: 'old-a', b: 'old-b' }],
+      });
+      clipboard.applyMatrix([['new-a', 'new-b']], 0, 'a');
+      expect(grid.getCell(0, 'a')).toBe('new-a');
+      expect(grid.getCell(0, 'b')).toBe('old-b');
+    });
+  });
+
+  describe('deleteSelection', () => {
+    it('clears every selected cell', () => {
+      const { clipboard, selection, grid } = setup();
+      selection.selectCell({ row: 0, col: 'a' });
+      selection.extendTo({ row: 1, col: 'b' });
+      expect(clipboard.deleteSelection()).toBe(true);
+      expect(grid.getCell(0, 'a')).toBeNull();
+      expect(grid.getCell(0, 'b')).toBeNull();
+      expect(grid.getCell(1, 'a')).toBeNull();
+      expect(grid.getCell(1, 'b')).toBeNull();
+      // Untouched.
+      expect(grid.getCell(2, 'a')).toBe('a2');
+    });
+
+    it('returns false when the selection is empty', () => {
+      const { clipboard } = setup();
+      expect(clipboard.deleteSelection()).toBe(false);
+    });
+
+    it('handles multi-range selections', () => {
+      const { clipboard, selection, grid } = setup();
+      selection.selectCell({ row: 0, col: 'a' });
+      selection.addCell({ row: 3, col: 'd' });
+      expect(clipboard.deleteSelection()).toBe(true);
+      expect(grid.getCell(0, 'a')).toBeNull();
+      expect(grid.getCell(3, 'd')).toBeNull();
+      expect(grid.getCell(1, 'a')).toBe('a1');
+    });
+
+    it('returns true even when every selected cell is already null', () => {
+      const { clipboard, selection } = setup({
+        data: [{ a: null, b: null }],
+        columns: [
+          { id: 'a', header: 'A', type: 'text' },
+          { id: 'b', header: 'B', type: 'text' },
+        ],
+      });
+      selection.selectCell({ row: 0, col: 'a' });
+      selection.extendTo({ row: 0, col: 'b' });
+      // Contract: "was a selection handled?", not "did any cell change value?"
+      expect(clipboard.deleteSelection()).toBe(true);
+    });
+
+    it('leaves non-editable cells untouched', () => {
+      const { clipboard, selection, grid } = setup({
+        columns: [
+          { id: 'a', header: 'A', type: 'text' },
+          { id: 'b', header: 'B', type: 'text', editable: false },
+        ],
+        data: [{ a: 'old-a', b: 'old-b' }],
+      });
+      selection.selectCell({ row: 0, col: 'a' });
+      selection.extendTo({ row: 0, col: 'b' });
+      clipboard.deleteSelection();
+      expect(grid.getCell(0, 'a')).toBeNull();
+      expect(grid.getCell(0, 'b')).toBe('old-b');
+    });
+  });
+
+  // ─── Navigator.clipboard integration ────────────────────────
+
+  describe('copy / cut / paste (with mocked Clipboard API)', () => {
+    const originalClipboard = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(navigator),
+      'clipboard',
+    );
+    let writeText: ReturnType<typeof vi.fn>;
+    let readText: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      writeText = vi.fn().mockResolvedValue(undefined);
+      readText = vi.fn().mockResolvedValue('');
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText, readText },
+      });
+    });
+
+    afterEach(() => {
+      if (originalClipboard) {
+        Object.defineProperty(Object.getPrototypeOf(navigator), 'clipboard', originalClipboard);
+      } else {
+        delete (navigator as { clipboard?: unknown }).clipboard;
+      }
+    });
+
+    it('copy writes TSV to the clipboard and emits clipboard:copy', async () => {
+      const { clipboard, selection, grid } = setup();
+      const handler = vi.fn();
+      grid.subscribe('clipboard:copy', handler);
+      selection.selectCell({ row: 0, col: 'a' });
+      selection.extendTo({ row: 1, col: 'b' });
+      const ok = await clipboard.copy();
+      expect(ok).toBe(true);
+      expect(writeText).toHaveBeenCalledWith('a0\t10\na1\t20');
+      expect(handler).toHaveBeenCalledWith(expect.objectContaining({ rows: 2, cols: 2 }));
+    });
+
+    it('copy returns false when the selection is empty', async () => {
+      const { clipboard } = setup();
+      const ok = await clipboard.copy();
+      expect(ok).toBe(false);
+      expect(writeText).not.toHaveBeenCalled();
+    });
+
+    it('copy succeeds for a single empty cell and writes an empty TSV', async () => {
+      const grid = createGrid({
+        data: [{ a: null }],
+        columns: [{ id: 'a', header: 'A', type: 'text' }],
+        plugins: [createSelectionPlugin(), createClipboardPlugin()],
+      });
+      const selection = grid.getPlugin<SelectionPluginApi>('selection')!;
+      const clipboard = grid.getPlugin<ClipboardPluginApi>('clipboard')!;
+      selection.selectCell({ row: 0, col: 'a' });
+      const ok = await clipboard.copy();
+      expect(ok).toBe(true);
+      expect(writeText).toHaveBeenCalledWith('');
+    });
+
+    it('cut copies then clears the source range', async () => {
+      const { clipboard, selection, grid } = setup();
+      selection.selectCell({ row: 0, col: 'a' });
+      selection.extendTo({ row: 0, col: 'b' });
+      const ok = await clipboard.cut();
+      expect(ok).toBe(true);
+      expect(writeText).toHaveBeenCalledWith('a0\t10');
+      expect(grid.getCell(0, 'a')).toBeNull();
+      expect(grid.getCell(0, 'b')).toBeNull();
+    });
+
+    it('paste reads TSV and applies it at the active cell', async () => {
+      const { clipboard, selection, grid } = setup();
+      selection.selectCell({ row: 2, col: 'a' });
+      readText.mockResolvedValue('X\t99\nZ\t100');
+      const ok = await clipboard.paste();
+      expect(ok).toBe(true);
+      expect(grid.getCell(2, 'a')).toBe('X');
+      expect(grid.getCell(2, 'b')).toBe(99);
+      expect(grid.getCell(3, 'a')).toBe('Z');
+      expect(grid.getCell(3, 'b')).toBe(100);
+    });
+
+    it('paste keeps non-numeric strings as raw text when the column type cannot coerce them', async () => {
+      const { clipboard, selection, grid } = setup();
+      selection.selectCell({ row: 2, col: 'b' });
+      readText.mockResolvedValue('not-a-number');
+      const ok = await clipboard.paste();
+      expect(ok).toBe(true);
+      expect(grid.getCell(2, 'b')).toBe('not-a-number');
+    });
+
+    it('paste is a no-op when there is no active cell', async () => {
+      const { clipboard } = setup();
+      readText.mockResolvedValue('a\tb');
+      const ok = await clipboard.paste();
+      expect(ok).toBe(false);
+    });
+
+    it('copy returns false when the Clipboard API rejects', async () => {
+      writeText.mockRejectedValueOnce(new Error('permission denied'));
+      const { clipboard, selection } = setup();
+      selection.selectCell({ row: 0, col: 'a' });
+      const ok = await clipboard.copy();
+      expect(ok).toBe(false);
+    });
+  });
+
+  describe('copy / paste without a Clipboard API', () => {
+    const originalClipboard = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(navigator),
+      'clipboard',
+    );
+
+    beforeEach(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: undefined,
+      });
+    });
+
+    afterEach(() => {
+      if (originalClipboard) {
+        Object.defineProperty(Object.getPrototypeOf(navigator), 'clipboard', originalClipboard);
+      } else {
+        delete (navigator as { clipboard?: unknown }).clipboard;
+      }
+    });
+
+    it('returns false when the clipboard is unavailable', async () => {
+      const { clipboard, selection } = setup();
+      selection.selectCell({ row: 0, col: 'a' });
+      expect(await clipboard.copy()).toBe(false);
+      expect(await clipboard.cut()).toBe(false);
+      expect(await clipboard.paste()).toBe(false);
+    });
+  });
+
+  describe('range invariants', () => {
+    it('serializes correctly when the range is created in reverse order', () => {
+      const { clipboard } = setup();
+      // startCol 'b' > endCol 'a' by column index, but range must still cover both.
+      const payload = clipboard.serializeRange({
+        startRow: 1,
+        endRow: 0,
+        startCol: 'b',
+        endCol: 'a',
+      });
+      expect(payload.text).toBe('a0\t10\na1\t20');
+    });
+  });
+});

--- a/packages/core/src/clipboard.ts
+++ b/packages/core/src/clipboard.ts
@@ -1,0 +1,450 @@
+import type {
+  CellRange,
+  CellValue,
+  ClipboardPayload,
+  ClipboardPluginApi,
+  ColumnDef,
+  ColumnType,
+  GridPlugin,
+  SelectionPluginApi,
+} from './types';
+
+// ─── Formatting ─────────────────────────────────────────────
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+function formatCell(value: CellValue): string {
+  if (value == null) return '';
+  if (value instanceof Date) {
+    return `${value.getFullYear()}-${pad2(value.getMonth() + 1)}-${pad2(value.getDate())}`;
+  }
+  if (typeof value === 'boolean') return value ? 'TRUE' : 'FALSE';
+  return String(value);
+}
+
+function parseCell(raw: string, type: ColumnType | undefined): CellValue {
+  if (raw === '') return null;
+  switch (type) {
+    case 'number': {
+      const n = Number(raw);
+      return Number.isFinite(n) ? n : raw;
+    }
+    case 'checkbox': {
+      const u = raw.toUpperCase();
+      if (u === 'TRUE' || u === '1') return true;
+      if (u === 'FALSE' || u === '0') return false;
+      return raw;
+    }
+    case 'date': {
+      const d = new Date(raw);
+      return Number.isNaN(d.getTime()) ? raw : d;
+    }
+    default:
+      return raw;
+  }
+}
+
+// ─── TSV ────────────────────────────────────────────────────
+
+function tsvEscape(cell: string): string {
+  // Only quote when the value contains a delimiter, a newline, or a quote —
+  // matches what Excel writes and keeps the common case un-quoted.
+  if (/[\t\r\n"]/.test(cell)) {
+    return `"${cell.replace(/"/g, '""')}"`;
+  }
+  return cell;
+}
+
+function serializeTsv(matrix: readonly (readonly string[])[]): string {
+  return matrix.map((row) => row.map(tsvEscape).join('\t')).join('\n');
+}
+
+/**
+ * Parse TSV text into a 2-D string matrix. Supports quoted cells with
+ * embedded tabs, quotes (doubled), and newlines (CRLF/LF/CR). Trailing empty
+ * line is dropped to match Excel's copy output.
+ */
+function parseTsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = '';
+  let inQuotes = false;
+  let i = 0;
+  const pushCell = () => {
+    row.push(cell);
+    cell = '';
+  };
+  const pushRow = () => {
+    row.push(cell);
+    rows.push(row);
+    row = [];
+    cell = '';
+  };
+  while (i < text.length) {
+    const ch = text[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          cell += '"';
+          i += 2;
+          continue;
+        }
+        inQuotes = false;
+        i += 1;
+        continue;
+      }
+      cell += ch;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' && cell === '') {
+      inQuotes = true;
+      i += 1;
+      continue;
+    }
+    if (ch === '\t') {
+      pushCell();
+      i += 1;
+      continue;
+    }
+    if (ch === '\r' || ch === '\n') {
+      pushRow();
+      if (ch === '\r' && text[i + 1] === '\n') i += 2;
+      else i += 1;
+      continue;
+    }
+    cell += ch;
+    i += 1;
+  }
+  // Flush the final cell/row when the payload did not end in a newline.
+  if (cell !== '' || row.length > 0 || inQuotes) pushRow();
+  // Excel appends a trailing newline, which produces an empty final row here.
+  if (rows.length > 0) {
+    const last = rows[rows.length - 1];
+    if (last.length === 1 && last[0] === '') rows.pop();
+  }
+  return rows;
+}
+
+// ─── HTML ───────────────────────────────────────────────────
+
+function htmlEscape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function serializeHtml(matrix: readonly (readonly string[])[]): string {
+  const body = matrix
+    .map(
+      (row) =>
+        `<tr>${row.map((c) => `<td>${htmlEscape(c).replace(/\n/g, '<br>')}</td>`).join('')}</tr>`,
+    )
+    .join('');
+  return `<table><tbody>${body}</tbody></table>`;
+}
+
+/**
+ * Parse HTML containing a single `<table>` into a 2-D string matrix. Returns
+ * null if no table is present — callers fall back to TSV in that case. Uses
+ * DOMParser when available; otherwise returns null (Node environments rely
+ * on the TSV path).
+ */
+function parseHtml(html: string): string[][] | null {
+  if (typeof DOMParser === 'undefined') return null;
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const table = doc.querySelector('table');
+  if (!table) return null;
+  const rows: string[][] = [];
+  for (const tr of Array.from(table.querySelectorAll('tr'))) {
+    const cells = Array.from(tr.querySelectorAll('td, th')).map((td) => {
+      // `textContent` preserves whitespace; `<br>` becomes a newline so
+      // multi-line cells roundtrip via HTML.
+      const clone = td.cloneNode(true) as HTMLElement;
+      clone.querySelectorAll('br').forEach((br) => br.replaceWith('\n'));
+      return clone.textContent ?? '';
+    });
+    if (cells.length > 0) rows.push(cells);
+  }
+  return rows;
+}
+
+// ─── Column utilities ───────────────────────────────────────
+
+function colRangeIndices(
+  range: CellRange,
+  columns: readonly ColumnDef[],
+): { startIdx: number; endIdx: number } {
+  const startIdx = columns.findIndex((c) => c.id === range.startCol);
+  const endIdx = columns.findIndex((c) => c.id === range.endCol);
+  // When an id isn't resolvable (stale after column change), treat the range
+  // as degenerate — the caller checks for -1 and bails.
+  if (startIdx === -1 || endIdx === -1) return { startIdx: -1, endIdx: -1 };
+  return {
+    startIdx: Math.min(startIdx, endIdx),
+    endIdx: Math.max(startIdx, endIdx),
+  };
+}
+
+// ─── Clipboard I/O (DOM) ────────────────────────────────────
+
+async function writeToClipboard(payload: ClipboardPayload): Promise<boolean> {
+  if (typeof navigator === 'undefined' || !navigator.clipboard) return false;
+  // Prefer `write` so HTML rides along for rich-paste targets. Not every
+  // browser (or permission policy) allows it — fall back to plain text on
+  // any failure.
+  if (typeof ClipboardItem !== 'undefined' && navigator.clipboard.write) {
+    try {
+      const item = new ClipboardItem({
+        'text/plain': new Blob([payload.text], { type: 'text/plain' }),
+        'text/html': new Blob([payload.html], { type: 'text/html' }),
+      });
+      await navigator.clipboard.write([item]);
+      return true;
+    } catch {
+      // fall through to writeText
+    }
+  }
+  if (!navigator.clipboard.writeText) return false;
+  try {
+    await navigator.clipboard.writeText(payload.text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readFromClipboard(): Promise<{ text?: string; html?: string } | null> {
+  if (typeof navigator === 'undefined' || !navigator.clipboard) return null;
+  if (navigator.clipboard.read) {
+    try {
+      const items = await navigator.clipboard.read();
+      let text: string | undefined;
+      let html: string | undefined;
+      for (const item of items) {
+        if (!html && item.types.includes('text/html')) {
+          html = await (await item.getType('text/html')).text();
+        }
+        if (!text && item.types.includes('text/plain')) {
+          text = await (await item.getType('text/plain')).text();
+        }
+      }
+      if (text !== undefined || html !== undefined) return { text, html };
+    } catch {
+      // fall through to readText
+    }
+  }
+  if (!navigator.clipboard.readText) return null;
+  try {
+    const text = await navigator.clipboard.readText();
+    return { text };
+  } catch {
+    return null;
+  }
+}
+
+// ─── Plugin ─────────────────────────────────────────────────
+
+export function createClipboardPlugin(): GridPlugin {
+  const plugin: GridPlugin = {
+    name: 'clipboard',
+    dependencies: ['selection'],
+
+    init(ctx) {
+      const columnsOf = () => ctx.grid.columns.get();
+
+      const getSelectionApi = (): SelectionPluginApi | undefined =>
+        ctx.getPlugin<SelectionPluginApi>('selection');
+
+      /**
+       * Pick the range we treat as "the selection" for copy/cut. Matches
+       * Excel's rule that clipboard ops bind to the most recently anchored
+       * range (the one containing `activeCell`).
+       */
+      const activeRange = (): CellRange | null => {
+        const sel = getSelectionApi()?.getState();
+        if (!sel || sel.ranges.length === 0) return null;
+        return sel.ranges[sel.ranges.length - 1];
+      };
+
+      const rangeMatrix = (range: CellRange): string[][] => {
+        const cols = columnsOf();
+        const { startIdx, endIdx } = colRangeIndices(range, cols);
+        if (startIdx === -1) return [];
+        const rowCount = ctx.grid.rowCount;
+        const startRow = Math.max(0, Math.min(range.startRow, range.endRow));
+        const endRow = Math.min(rowCount - 1, Math.max(range.startRow, range.endRow));
+        const out: string[][] = [];
+        for (let r = startRow; r <= endRow; r++) {
+          const row: string[] = [];
+          for (let c = startIdx; c <= endIdx; c++) {
+            row.push(formatCell(ctx.grid.getCell(r, cols[c].id)));
+          }
+          out.push(row);
+        }
+        return out;
+      };
+
+      const serializeRange = (range: CellRange): ClipboardPayload => {
+        const matrix = rangeMatrix(range);
+        return { text: serializeTsv(matrix), html: serializeHtml(matrix) };
+      };
+
+      const parsePayload = (payload: { text?: string; html?: string }): string[][] | null => {
+        if (payload.html) {
+          const parsed = parseHtml(payload.html);
+          // Only prefer HTML when it produced actual rows — an empty
+          // `<table>` should fall through to the TSV payload if present.
+          if (parsed && parsed.length > 0) return parsed;
+        }
+        if (payload.text !== undefined) {
+          const parsed = parseTsv(payload.text);
+          return parsed.length > 0 ? parsed : null;
+        }
+        return null;
+      };
+
+      const applyMatrix: ClipboardPluginApi['applyMatrix'] = (matrix, startRow, startCol) => {
+        if (matrix.length === 0) return;
+        const cols = columnsOf();
+        const startIdx = cols.findIndex((c) => c.id === startCol);
+        if (startIdx === -1) return;
+        const rowCount = ctx.grid.rowCount;
+        ctx.grid.batchUpdate(() => {
+          for (let r = 0; r < matrix.length; r++) {
+            const destRow = startRow + r;
+            if (destRow < 0 || destRow >= rowCount) continue;
+            const row = matrix[r];
+            for (let c = 0; c < row.length; c++) {
+              const destCol = cols[startIdx + c];
+              if (!destCol) continue;
+              if (destCol.editable === false) continue;
+              const raw = row[c];
+              const value =
+                typeof raw === 'string' ? parseCell(raw, destCol.type) : (raw as CellValue);
+              ctx.grid.setCell(destRow, destCol.id, value);
+            }
+          }
+        });
+      };
+
+      const rangeSize = (range: CellRange): { rows: number; cols: number } => {
+        const cols = columnsOf();
+        const { startIdx, endIdx } = colRangeIndices(range, cols);
+        if (startIdx === -1) return { rows: 0, cols: 0 };
+        return {
+          rows: Math.abs(range.endRow - range.startRow) + 1,
+          cols: endIdx - startIdx + 1,
+        };
+      };
+
+      const deleteSelection = (): boolean => {
+        const sel = getSelectionApi()?.getState();
+        if (!sel || sel.ranges.length === 0) return false;
+        const cols = columnsOf();
+        const rowCount = ctx.grid.rowCount;
+        ctx.grid.batchUpdate(() => {
+          for (const r of sel.ranges) {
+            const { startIdx, endIdx } = colRangeIndices(r, cols);
+            if (startIdx === -1) continue;
+            const startRow = Math.max(0, Math.min(r.startRow, r.endRow));
+            const endRow = Math.min(rowCount - 1, Math.max(r.startRow, r.endRow));
+            for (let row = startRow; row <= endRow; row++) {
+              for (let c = startIdx; c <= endIdx; c++) {
+                const col = cols[c];
+                if (col.editable === false) continue;
+                // Skip cells already null — avoids a redundant data:change and
+                // keeps the batch minimal, but the overall return is still
+                // "handled" because a selection existed.
+                if (ctx.grid.getCell(row, col.id) == null) continue;
+                ctx.grid.setCell(row, col.id, null);
+              }
+            }
+          }
+        });
+        return true;
+      };
+
+      const api: ClipboardPluginApi = {
+        async copy() {
+          const range = activeRange();
+          if (!range) return false;
+          // Only bail when the range itself is unresolvable (stale column ids,
+          // zero rows). An all-empty range still serializes to tabs/newlines
+          // and should round-trip faithfully.
+          if (rangeMatrix(range).length === 0) return false;
+          const payload = serializeRange(range);
+          const ok = await writeToClipboard(payload);
+          if (ok) {
+            const { rows, cols } = rangeSize(range);
+            ctx.events.emit('clipboard:copy', { range, rows, cols });
+          }
+          return ok;
+        },
+
+        async cut() {
+          const range = activeRange();
+          if (!range) return false;
+          if (rangeMatrix(range).length === 0) return false;
+          const payload = serializeRange(range);
+          const ok = await writeToClipboard(payload);
+          if (!ok) return false;
+          const cols = columnsOf();
+          const { startIdx, endIdx } = colRangeIndices(range, cols);
+          const rowCount = ctx.grid.rowCount;
+          ctx.grid.batchUpdate(() => {
+            const startRow = Math.max(0, Math.min(range.startRow, range.endRow));
+            const endRow = Math.min(rowCount - 1, Math.max(range.startRow, range.endRow));
+            for (let r = startRow; r <= endRow; r++) {
+              for (let c = startIdx; c <= endIdx; c++) {
+                const col = cols[c];
+                if (col.editable === false) continue;
+                ctx.grid.setCell(r, col.id, null);
+              }
+            }
+          });
+          const size = rangeSize(range);
+          ctx.events.emit('clipboard:cut', { range, rows: size.rows, cols: size.cols });
+          return true;
+        },
+
+        async paste() {
+          const sel = getSelectionApi()?.getState();
+          const target = sel?.activeCell ?? null;
+          if (!target) return false;
+          const payload = await readFromClipboard();
+          if (!payload) return false;
+          const matrix = parsePayload(payload);
+          if (!matrix || matrix.length === 0) return false;
+          applyMatrix(matrix, target.row, target.col);
+          ctx.events.emit('clipboard:paste', {
+            target: { ...target },
+            rows: matrix.length,
+            cols: matrix[0]?.length ?? 0,
+          });
+          return true;
+        },
+
+        deleteSelection,
+        serializeRange,
+        parsePayload,
+        applyMatrix,
+      };
+
+      ctx.expose('clipboard', api);
+
+      // No subscriptions today, but match the selection/editing plugin
+      // convention so future additions (e.g. copy-marquee decoration) don't
+      // silently leak listeners.
+      return () => {
+        /* noop */
+      };
+    },
+  };
+
+  return plugin;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,9 @@ export { createEditingPlugin } from './editing';
 // Selection
 export { createSelectionPlugin } from './selection';
 
+// Clipboard
+export { createClipboardPlugin } from './clipboard';
+
 // Column grouping
 export {
   flattenColumns,
@@ -67,6 +70,9 @@ export type {
   SelectionState,
   SelectionMode,
   SelectionPluginApi,
+  ClipboardPayload,
+  ClipboardMatrix,
+  ClipboardPluginApi,
   CellDecoration,
   CellDecorator,
   PluginContext,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -152,6 +152,9 @@ export interface GridEvents {
   };
   'edit:cancel': { rowIndex: number; columnId: string };
   'selection:change': SelectionState;
+  'clipboard:copy': { range: CellRange; rows: number; cols: number };
+  'clipboard:cut': { range: CellRange; rows: number; cols: number };
+  'clipboard:paste': { target: CellCoord; rows: number; cols: number };
   'plugin:ready': { name: string };
   ready: undefined;
   destroy: undefined;
@@ -242,6 +245,48 @@ export interface EditingPluginApi {
   defineEditor(def: EditorDefinition): void;
   getEditor(name: string): EditorDefinition | undefined;
   setValue(value: CellValue): void;
+}
+
+// ─── Clipboard ────────────────────────────────────────────
+
+/** A 2-D matrix of cell values laid out as rows of columns. */
+export type ClipboardMatrix = readonly (readonly CellValue[])[];
+
+/** Dual-format clipboard payload written on copy/cut. */
+export interface ClipboardPayload {
+  /** Tab-separated values (Excel/Sheets interop format). */
+  text: string;
+  /** Minimal `<table>` HTML. Written for apps that prefer rich paste. */
+  html: string;
+}
+
+export interface ClipboardPluginApi {
+  /**
+   * Serialize the active selection range and write TSV + HTML to the system
+   * clipboard. Resolves `true` on success, `false` if there is nothing to
+   * copy or the Clipboard API is unavailable/denied.
+   */
+  copy(): Promise<boolean>;
+  /** Copy, then null-out the source cells. */
+  cut(): Promise<boolean>;
+  /** Read TSV/HTML from the system clipboard and paste at the active cell. */
+  paste(): Promise<boolean>;
+  /** Clear (set to null) every editable cell in the current selection. */
+  deleteSelection(): boolean;
+  /** Build a TSV+HTML payload for an arbitrary rectangular range. */
+  serializeRange(range: CellRange): ClipboardPayload;
+  /**
+   * Parse a `{ text, html }` clipboard payload into a string matrix. Values
+   * are returned as raw strings — type coercion happens in `applyMatrix`,
+   * where the target column type is known. Returns null if nothing
+   * parseable was provided.
+   */
+  parsePayload(payload: { text?: string; html?: string }): string[][] | null;
+  /**
+   * Write `matrix` into the grid starting at `(startRow, startCol)`. Values
+   * are coerced per target column type. Out-of-bounds cells are skipped.
+   */
+  applyMatrix(matrix: ClipboardMatrix, startRow: number, startCol: string): void;
 }
 
 // ─── Plugin ────────────────────────────────────────────────

--- a/packages/react/src/grid.tsx
+++ b/packages/react/src/grid.tsx
@@ -1,5 +1,6 @@
 import {
   type CellValue,
+  type ClipboardPluginApi,
   type EditingPluginApi,
   type EditState,
   type FilterEntry,
@@ -12,6 +13,7 @@ import {
   calculateVisibleRange,
   columnStructureKey,
   computeColumnLayout,
+  createClipboardPlugin,
   createEditingPlugin,
   createSelectionPlugin,
   flattenColumns,
@@ -117,7 +119,8 @@ export const Grid = memo(function Grid({
   const [allPlugins] = useState(() => {
     const editingPlugin = createEditingPlugin();
     const selectionPlugin = createSelectionPlugin();
-    const builtins = [editingPlugin, selectionPlugin];
+    const clipboardPlugin = createClipboardPlugin();
+    const builtins = [editingPlugin, selectionPlugin, clipboardPlugin];
     return plugins ? [...builtins, ...plugins] : builtins;
   });
 
@@ -192,6 +195,12 @@ export const Grid = memo(function Grid({
   const selectionApi = useMemo(() => {
     const api = grid.getPlugin<SelectionPluginApi>('selection');
     if (!api) throw new Error('Selection plugin not found — this should not happen');
+    return api;
+  }, [grid]);
+
+  const clipboardApi = useMemo(() => {
+    const api = grid.getPlugin<ClipboardPluginApi>('clipboard');
+    if (!api) throw new Error('Clipboard plugin not found — this should not happen');
     return api;
   }, [grid]);
 
@@ -1129,6 +1138,32 @@ export const Grid = memo(function Grid({
         return;
       }
 
+      // Ctrl/Cmd+C / X / V — clipboard. Only plain modifiers: combos like
+      // Ctrl+Shift+C (DevTools) or Alt+Ctrl+V belong to the browser/OS, so
+      // we explicitly opt out of intercepting them. Sibling inputs (filter
+      // textbox etc.) also keep their native clipboard behavior.
+      if (mod && !e.shiftKey && !e.altKey && !fromTextInput) {
+        const k = e.key.toLowerCase();
+        if (k === 'c') {
+          if (selectionApi.getState().ranges.length === 0) return;
+          e.preventDefault();
+          void clipboardApi.copy();
+          return;
+        }
+        if (k === 'x') {
+          if (selectionApi.getState().ranges.length === 0) return;
+          e.preventDefault();
+          void clipboardApi.cut();
+          return;
+        }
+        if (k === 'v') {
+          if (!selectionApi.getState().activeCell) return;
+          e.preventDefault();
+          void clipboardApi.paste();
+          return;
+        }
+      }
+
       // Escape clears the selection (Excel parity). Only when not editing —
       // the editor's Escape handler runs first via the early-return above.
       if (e.key === 'Escape') {
@@ -1259,9 +1294,15 @@ export const Grid = memo(function Grid({
 
       if (e.key === 'Delete' || e.key === 'Backspace') {
         e.preventDefault();
-        const colDef = currentColumns[focusedCell.colIndex];
-        if (colDef && colDef.editable !== false) {
-          grid.setCell(focusedCell.row, focusedCell.col, null);
+        // Prefer the full selection when it covers more than just the active
+        // cell; fall back to the single focused cell so keyboard-driven focus
+        // without an explicit selection still works.
+        const cleared = clipboardApi.deleteSelection();
+        if (!cleared) {
+          const colDef = currentColumns[focusedCell.colIndex];
+          if (colDef && colDef.editable !== false) {
+            grid.setCell(focusedCell.row, focusedCell.col, null);
+          }
         }
         return;
       }
@@ -1288,6 +1329,7 @@ export const Grid = memo(function Grid({
       currentColumns,
       editingApi,
       selectionApi,
+      clipboardApi,
       grid,
       moveFocusTo,
       stepVisibleCol,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -7,6 +7,7 @@ export type { UseGridOptions } from './use-grid';
 export { useSignalValue } from './use-signal';
 export { useGridSelection } from './use-grid-selection';
 export type { SelectionState } from './use-grid-selection';
+export { useGridClipboard } from './use-grid-clipboard';
 
 // Types
 export type { GridProps, GridColumnDef, CellRendererProps, CellEditorProps } from './types';
@@ -35,6 +36,10 @@ export {
   type GridPlugin,
   type GridOptions,
   type HeaderCell,
+  type ClipboardPluginApi,
+  type ClipboardPayload,
+  type ClipboardMatrix,
+  createClipboardPlugin,
   createEditingPlugin,
   flattenColumns,
   getHeaderDepth,

--- a/packages/react/src/use-grid-clipboard.ts
+++ b/packages/react/src/use-grid-clipboard.ts
@@ -1,0 +1,10 @@
+import type { ClipboardPluginApi, GridInstance } from '@gridsmith/core';
+import { useMemo } from 'react';
+
+/**
+ * Read the clipboard plugin API off a grid instance. Returns the same
+ * reference across renders for stable callback identities.
+ */
+export function useGridClipboard(grid: GridInstance): ClipboardPluginApi | null {
+  return useMemo(() => grid.getPlugin<ClipboardPluginApi>('clipboard') ?? null, [grid]);
+}


### PR DESCRIPTION
## Summary

- New `'clipboard'` plugin in `@gridsmith/core` that round-trips cell values with Excel and Google Sheets via dual-format payloads (TSV `text/plain` + minimal `<table>` `text/html`), with a `writeText` fallback when rich `ClipboardItem` writes are unavailable or denied.
- New `ClipboardPluginApi`: `copy`, `cut`, `paste`, `deleteSelection`, `serializeRange`, `parsePayload`, `applyMatrix`. Type coercion per target column (`number`, `checkbox`, `date`) on paste; booleans serialize as `TRUE`/`FALSE`, dates as `YYYY-MM-DD`, nulls as empty. New events `clipboard:copy`, `clipboard:cut`, `clipboard:paste`.
- `@gridsmith/react` auto-registers the plugin alongside editing and selection, wires Ctrl/Cmd+C/X/V and Delete/Backspace (only when the grid itself is focused — sibling text inputs keep native behavior), and exposes `useGridClipboard(grid)` for programmatic access.

Closes #11.

## Test plan

- [x] `pnpm turbo build type-check test` — all 9 tasks cached/green; 278 core tests + 173 react tests pass
- [x] `pnpm format:check` clean
- [x] New spec `clipboard.spec.ts` (34 tests, jsdom env): TSV/HTML serialize+parse round-trip, Excel CRLF/quoted-newline handling, type coercion on paste, empty-range + empty-cell behavior, `ClipboardItem` → `writeText` fallback, non-editable column skip, `deleteSelection` batching
- [ ] Manual: copy from grid → paste into Excel / Google Sheets (and reverse) to confirm round-trip fidelity

🤖 Generated with [Claude Code](https://claude.com/claude-code)