### PR TITLE
feat: excel-style fill handle with pattern recognition (#12)

### DIFF
--- a/.changeset/fill-handle.md
+++ b/.changeset/fill-handle.md
@@ -1,0 +1,53 @@
+---
+'@gridsmith/core': minor
+'@gridsmith/react': minor
+---
+
+Add Excel-style fill handle with pattern recognition.
+
+**Core (`@gridsmith/core`):**
+
+- New `createFillHandlePlugin(options?)` exports a `'fill-handle'` plugin
+  that extends a source range into a larger target range along one axis,
+  inferring a pattern from the source values.
+- `inferPattern(values)` detects: arithmetic progressions (integer or
+  float with a small tolerance), dates advanced by one day, short/long
+  day-of-week names (Mon/Monday, case-insensitive), short/long month
+  names (Jan/January), prefix-number strings (`Q1`, `item-7`), any
+  registered custom list, and falls back to `copy` otherwise. A single
+  cell that matches a known list (built-in or custom) also extrapolates
+  as that list — matching Excel's behavior when dragging a single "Mon"
+  or "January".
+- `generateValues(source, count, direction)` produces forward or reverse
+  extrapolations, cycling lists with a modular wrap so a day-name drag
+  of any length wraps cleanly past the week boundary.
+- `fill({ source, target })` applies the inferred pattern across the
+  extension, skipping columns where `editable === false`. Rejects
+  targets that don't strictly enclose the source, and rejects
+  two-axis extensions (Excel only extrapolates along one axis).
+- All writes go through `grid.batchUpdate()`, so a full fill is one
+  undo step and all downstream listeners (including the history plugin)
+  see a single transaction.
+- `registerCustomList(list)` / `getCustomLists()` let callers add their
+  own cyclic lists at runtime; built-in day/month lists are always
+  active. Initial lists can also be passed via the `customLists` option.
+- New types: `FillPatternKind`, `FillDirection`, `FillPattern`,
+  `FillOperation`, `FillHandlePluginOptions`, `FillHandlePluginApi`.
+
+**React (`@gridsmith/react`):**
+
+- Auto-registers the fill-handle plugin alongside editing, selection,
+  clipboard, and history.
+- Renders an 8×8 handle at the bottom-right corner of the active
+  selection range when not editing. Pointer-drag on the handle extends
+  the selection and fills on release; direction is chosen by the
+  dominant axis of the drag. During the drag a dashed preview rectangle
+  shows the pending target.
+- After a successful fill the target range becomes the new selection,
+  matching Excel.
+- New `useGridFillHandle(grid)` hook returns the plugin API (or `null`
+  if the plugin isn't registered) for callers that want to trigger
+  fills programmatically or register custom lists.
+- Re-exports `createFillHandlePlugin`, `FillHandlePluginApi`,
+  `FillHandlePluginOptions`, `FillPattern`, `FillPatternKind`,
+  `FillDirection`, and `FillOperation` for direct API use.

--- a/packages/core/src/fill-handle.spec.ts
+++ b/packages/core/src/fill-handle.spec.ts
@@ -1,0 +1,307 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+
+import { createFillHandlePlugin } from './fill-handle';
+import { createGrid } from './grid';
+import { createHistoryPlugin } from './history';
+import { createSelectionPlugin } from './selection';
+import type {
+  CellRange,
+  ColumnDef,
+  FillHandlePluginApi,
+  HistoryPluginApi,
+  Row,
+  SelectionPluginApi,
+} from './types';
+
+const columns: ColumnDef[] = [
+  { id: 'a', header: 'A', type: 'text' },
+  { id: 'b', header: 'B', type: 'number' },
+  { id: 'c', header: 'C', type: 'text' },
+  { id: 'd', header: 'D', type: 'date' },
+];
+
+function makeRows(n: number): Row[] {
+  const out: Row[] = [];
+  for (let i = 0; i < n; i++) out.push({ a: null, b: null, c: null, d: null });
+  return out;
+}
+
+interface Setup {
+  grid: ReturnType<typeof createGrid>;
+  selection: SelectionPluginApi;
+  history: HistoryPluginApi;
+  fill: FillHandlePluginApi;
+}
+
+function setup(overrides: { data?: Row[]; columns?: ColumnDef[] } = {}): Setup {
+  const grid = createGrid({
+    data: overrides.data ?? makeRows(12),
+    columns: overrides.columns ?? columns,
+    plugins: [createSelectionPlugin(), createHistoryPlugin(), createFillHandlePlugin()],
+  });
+  return {
+    grid,
+    selection: grid.getPlugin<SelectionPluginApi>('selection')!,
+    history: grid.getPlugin<HistoryPluginApi>('history')!,
+    fill: grid.getPlugin<FillHandlePluginApi>('fill-handle')!,
+  };
+}
+
+function range(startRow: number, endRow: number, startCol: string, endCol: string): CellRange {
+  return { startRow, endRow, startCol, endCol };
+}
+
+describe('fill-handle plugin', () => {
+  describe('inferPattern', () => {
+    it('detects arithmetic progressions over numbers', () => {
+      const { fill } = setup();
+      expect(fill.inferPattern([1, 2, 3]).kind).toBe('arithmetic');
+      expect(fill.inferPattern([2, 4, 6, 8]).kind).toBe('arithmetic');
+      expect(fill.inferPattern([10, 5, 0]).kind).toBe('arithmetic');
+    });
+
+    it('treats constant numeric sequences as copy, not arithmetic', () => {
+      const { fill } = setup();
+      expect(fill.inferPattern([7, 7, 7]).kind).toBe('copy');
+    });
+
+    it('recognizes day-of-week short names case-insensitively', () => {
+      const { fill } = setup();
+      expect(fill.inferPattern(['Mon', 'Tue', 'Wed']).kind).toBe('day-name-short');
+      expect(fill.inferPattern(['mon', 'TUE', 'wed']).kind).toBe('day-name-short');
+    });
+
+    it('recognizes month-of-year long names', () => {
+      const { fill } = setup();
+      expect(fill.inferPattern(['January', 'February', 'March']).kind).toBe('month-name-long');
+    });
+
+    it('recognizes Date sequences with a constant day step', () => {
+      const { fill } = setup();
+      const start = new Date(2026, 0, 1);
+      const next = new Date(2026, 0, 2);
+      const third = new Date(2026, 0, 3);
+      expect(fill.inferPattern([start, next, third]).kind).toBe('date-day');
+    });
+
+    it('detects prefix+number sequences', () => {
+      const { fill } = setup();
+      expect(fill.inferPattern(['Q1', 'Q2', 'Q3']).kind).toBe('prefix-number');
+      expect(fill.inferPattern(['Item5', 'Item10', 'Item15']).kind).toBe('prefix-number');
+    });
+
+    it('honors registered custom lists', () => {
+      const { fill } = setup();
+      fill.registerCustomList(['North', 'East', 'South', 'West']);
+      expect(fill.inferPattern(['North', 'East', 'South']).kind).toBe('custom-list');
+    });
+
+    it('falls back to copy when nothing matches', () => {
+      const { fill } = setup();
+      expect(fill.inferPattern(['foo', 'bar']).kind).toBe('copy');
+      expect(fill.inferPattern([1, 'a']).kind).toBe('copy');
+    });
+  });
+
+  describe('generateValues', () => {
+    it('extrapolates arithmetic forward and reverse', () => {
+      const { fill } = setup();
+      expect(fill.generateValues([1, 2, 3], 3, 'forward')).toEqual([4, 5, 6]);
+      expect(fill.generateValues([1, 2, 3], 3, 'reverse')).toEqual([0, -1, -2]);
+    });
+
+    it('cycles copy seeds in both directions', () => {
+      const { fill } = setup();
+      expect(fill.generateValues(['a', 'b'], 4, 'forward')).toEqual(['a', 'b', 'a', 'b']);
+      expect(fill.generateValues(['a', 'b'], 3, 'reverse')).toEqual(['b', 'a', 'b']);
+    });
+
+    it('wraps day-of-week cycles', () => {
+      const { fill } = setup();
+      // Fri, Sat, Sun, Mon, Tue, Wed, Thu, Fri
+      expect(fill.generateValues(['Fri'], 4, 'forward')).toEqual(['Sat', 'Sun', 'Mon', 'Tue']);
+    });
+
+    it('wraps month names and preserves canonical casing', () => {
+      const { fill } = setup();
+      // Seeds "nov","dec" in any case round-trip through canonical list entries.
+      expect(fill.generateValues(['nov', 'dec'], 3, 'forward')).toEqual(['Jan', 'Feb', 'Mar']);
+    });
+
+    it('extends prefix+number progressions', () => {
+      const { fill } = setup();
+      expect(fill.generateValues(['Q1', 'Q2'], 3, 'forward')).toEqual(['Q3', 'Q4', 'Q5']);
+    });
+
+    it('adds days when extending a Date seed', () => {
+      const { fill } = setup();
+      const d1 = new Date(2026, 0, 1);
+      const d2 = new Date(2026, 0, 2);
+      const out = fill.generateValues([d1, d2], 2, 'forward') as Date[];
+      expect(out[0].getFullYear()).toBe(2026);
+      expect(out[0].getMonth()).toBe(0);
+      expect(out[0].getDate()).toBe(3);
+      expect(out[1].getDate()).toBe(4);
+    });
+  });
+
+  describe('fill', () => {
+    it('extends a numeric series down a single column', () => {
+      const { grid, fill } = setup();
+      grid.setCell(0, 'b', 1);
+      grid.setCell(1, 'b', 2);
+      const ok = fill.fill({
+        source: range(0, 1, 'b', 'b'),
+        target: range(0, 4, 'b', 'b'),
+      });
+      expect(ok).toBe(true);
+      expect(grid.getCell(2, 'b')).toBe(3);
+      expect(grid.getCell(3, 'b')).toBe(4);
+      expect(grid.getCell(4, 'b')).toBe(5);
+    });
+
+    it('extends upward from the top of the source', () => {
+      const { grid, fill } = setup();
+      grid.setCell(5, 'b', 10);
+      grid.setCell(6, 'b', 12);
+      fill.fill({
+        source: range(5, 6, 'b', 'b'),
+        target: range(3, 6, 'b', 'b'),
+      });
+      // step=2, base=10, reverse-1 row → 8, reverse-2 rows → 6
+      expect(grid.getCell(4, 'b')).toBe(8);
+      expect(grid.getCell(3, 'b')).toBe(6);
+    });
+
+    it('copies a single-cell seed when no pattern can be inferred', () => {
+      const { grid, fill } = setup();
+      grid.setCell(0, 'a', 'hello');
+      fill.fill({
+        source: range(0, 0, 'a', 'a'),
+        target: range(0, 3, 'a', 'a'),
+      });
+      expect(grid.getCell(1, 'a')).toBe('hello');
+      expect(grid.getCell(2, 'a')).toBe('hello');
+      expect(grid.getCell(3, 'a')).toBe('hello');
+    });
+
+    it('fills horizontally to the right across a row', () => {
+      const { grid, fill } = setup({
+        columns: [
+          { id: 'n1', header: '1', type: 'number' },
+          { id: 'n2', header: '2', type: 'number' },
+          { id: 'n3', header: '3', type: 'number' },
+          { id: 'n4', header: '4', type: 'number' },
+        ],
+        data: [{ n1: 10, n2: 20, n3: null, n4: null }],
+      });
+      fill.fill({
+        source: range(0, 0, 'n1', 'n2'),
+        target: range(0, 0, 'n1', 'n4'),
+      });
+      expect(grid.getCell(0, 'n3')).toBe(30);
+      expect(grid.getCell(0, 'n4')).toBe(40);
+    });
+
+    it('fills each column independently for a multi-column source', () => {
+      const { grid, fill } = setup({
+        columns: [
+          { id: 'x', header: 'X', type: 'number' },
+          { id: 'y', header: 'Y', type: 'number' },
+        ],
+        data: [
+          { x: 1, y: 10 },
+          { x: 2, y: 20 },
+          { x: null, y: null },
+          { x: null, y: null },
+        ],
+      });
+      fill.fill({
+        source: range(0, 1, 'x', 'y'),
+        target: range(0, 3, 'x', 'y'),
+      });
+      expect(grid.getCell(2, 'x')).toBe(3);
+      expect(grid.getCell(3, 'x')).toBe(4);
+      expect(grid.getCell(2, 'y')).toBe(30);
+      expect(grid.getCell(3, 'y')).toBe(40);
+    });
+
+    it('rejects targets smaller than source', () => {
+      const { grid, fill } = setup();
+      grid.setCell(0, 'b', 1);
+      grid.setCell(1, 'b', 2);
+      const ok = fill.fill({
+        source: range(0, 1, 'b', 'b'),
+        target: range(0, 0, 'b', 'b'),
+      });
+      expect(ok).toBe(false);
+    });
+
+    it('rejects two-axis extensions (ambiguous)', () => {
+      const { grid, fill } = setup();
+      grid.setCell(0, 'b', 1);
+      const ok = fill.fill({
+        source: range(0, 0, 'b', 'b'),
+        target: range(0, 2, 'b', 'c'),
+      });
+      expect(ok).toBe(false);
+    });
+
+    it('skips cells in non-editable columns', () => {
+      const { grid, fill } = setup({
+        columns: [
+          { id: 'b', header: 'B', type: 'number' },
+          { id: 'r', header: 'R', type: 'number', editable: false },
+        ],
+        data: [
+          { b: 1, r: 99 },
+          { b: 2, r: 99 },
+          { b: null, r: 99 },
+        ],
+      });
+      fill.fill({
+        source: range(0, 1, 'b', 'r'),
+        target: range(0, 2, 'b', 'r'),
+      });
+      expect(grid.getCell(2, 'b')).toBe(3);
+      expect(grid.getCell(2, 'r')).toBe(99);
+    });
+
+    it('records one undoable entry for the whole fill', () => {
+      const { grid, history, fill } = setup();
+      grid.setCell(0, 'b', 1);
+      grid.setCell(1, 'b', 2);
+      const before = history.getUndoSize();
+      fill.fill({
+        source: range(0, 1, 'b', 'b'),
+        target: range(0, 5, 'b', 'b'),
+      });
+      expect(history.getUndoSize()).toBe(before + 1);
+      history.undo();
+      expect(grid.getCell(2, 'b')).toBeNull();
+      expect(grid.getCell(3, 'b')).toBeNull();
+      // Seed cells untouched by the fill are preserved.
+      expect(grid.getCell(0, 'b')).toBe(1);
+      expect(grid.getCell(1, 'b')).toBe(2);
+      history.redo();
+      expect(grid.getCell(2, 'b')).toBe(3);
+      expect(grid.getCell(5, 'b')).toBe(6);
+    });
+
+    it('registers custom lists used by inferPattern and generateValues', () => {
+      const { grid, fill } = setup();
+      fill.registerCustomList(['Red', 'Green', 'Blue']);
+      grid.setCell(0, 'a', 'Red');
+      grid.setCell(1, 'a', 'Green');
+      fill.fill({
+        source: range(0, 1, 'a', 'a'),
+        target: range(0, 5, 'a', 'a'),
+      });
+      expect(grid.getCell(2, 'a')).toBe('Blue');
+      expect(grid.getCell(3, 'a')).toBe('Red');
+      expect(grid.getCell(4, 'a')).toBe('Green');
+      expect(grid.getCell(5, 'a')).toBe('Blue');
+    });
+  });
+});

--- a/packages/core/src/fill-handle.spec.ts
+++ b/packages/core/src/fill-handle.spec.ts
@@ -102,6 +102,24 @@ describe('fill-handle plugin', () => {
       expect(fill.inferPattern(['foo', 'bar']).kind).toBe('copy');
       expect(fill.inferPattern([1, 'a']).kind).toBe('copy');
     });
+
+    it('treats a single-cell seed that matches a built-in list as a list sequence', () => {
+      const { fill } = setup();
+      expect(fill.inferPattern(['Jan']).kind).toBe('month-name-short');
+      expect(fill.inferPattern(['January']).kind).toBe('month-name-long');
+    });
+
+    it('treats a single-cell seed that matches a custom list as a custom-list sequence', () => {
+      const { fill } = setup();
+      fill.registerCustomList(['Red', 'Green', 'Blue']);
+      expect(fill.inferPattern(['Green']).kind).toBe('custom-list');
+    });
+
+    it('falls back to copy for constant date sequences', () => {
+      const { fill } = setup();
+      const d = new Date(2026, 0, 1);
+      expect(fill.inferPattern([d, d, d]).kind).toBe('copy');
+    });
   });
 
   describe('generateValues', () => {
@@ -302,6 +320,33 @@ describe('fill-handle plugin', () => {
       expect(grid.getCell(3, 'a')).toBe('Red');
       expect(grid.getCell(4, 'a')).toBe('Green');
       expect(grid.getCell(5, 'a')).toBe('Blue');
+    });
+
+    it('exposes registered custom lists via getCustomLists', () => {
+      const { fill } = setup();
+      fill.registerCustomList(['Small', 'Medium', 'Large']);
+      const lists = fill.getCustomLists();
+      expect(lists).toHaveLength(1);
+      expect(lists[0]).toEqual(['Small', 'Medium', 'Large']);
+    });
+
+    it('extrapolates day-of-week long names and month-name short series', () => {
+      const { fill } = setup();
+      const days = fill.generateValues(['Monday', 'Tuesday'], 3, 'forward');
+      expect(days).toEqual(['Wednesday', 'Thursday', 'Friday']);
+      const months = fill.generateValues(['Jan', 'Feb'], 2, 'forward');
+      expect(months).toEqual(['Mar', 'Apr']);
+    });
+
+    it('fills columns to the left of the source when target extends leftward', () => {
+      const { grid, fill } = setup();
+      grid.setCell(0, 'b', 1);
+      grid.setCell(0, 'c', 2);
+      fill.fill({
+        source: range(0, 0, 'b', 'c'),
+        target: range(0, 0, 'a', 'c'),
+      });
+      expect(grid.getCell(0, 'a')).toBe(0);
     });
   });
 });

--- a/packages/core/src/fill-handle.ts
+++ b/packages/core/src/fill-handle.ts
@@ -1,0 +1,473 @@
+import type {
+  CellRange,
+  CellValue,
+  ColumnDef,
+  FillDirection,
+  FillHandlePluginApi,
+  FillHandlePluginOptions,
+  FillOperation,
+  FillPattern,
+  FillPatternKind,
+  GridPlugin,
+} from './types';
+
+// ─── Built-in cyclic lists ─────────────────────────────────
+
+const DAY_NAMES_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
+const DAY_NAMES_LONG = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+] as const;
+const MONTH_NAMES_SHORT = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+] as const;
+const MONTH_NAMES_LONG = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+] as const;
+
+// ─── Helpers ───────────────────────────────────────────────
+
+function findInList(list: readonly string[], value: string): number {
+  const lower = value.toLowerCase();
+  for (let i = 0; i < list.length; i++) {
+    if (list[i].toLowerCase() === lower) return i;
+  }
+  return -1;
+}
+
+/**
+ * Return the common difference if the sequence is an arithmetic progression,
+ * or `null` otherwise. Float inputs are compared with a relative tolerance so
+ * `0.1, 0.2, 0.3` is recognized despite IEEE rounding.
+ */
+function arithmeticStep(nums: readonly number[]): number | null {
+  if (nums.length < 2) return null;
+  const step = nums[1] - nums[0];
+  const tol = 1e-9 * Math.max(1, Math.abs(step));
+  for (let i = 2; i < nums.length; i++) {
+    const d = nums[i] - nums[i - 1];
+    if (Math.abs(d - step) > tol) return null;
+  }
+  return step;
+}
+
+const MS_PER_DAY = 86_400_000;
+
+function dateToDayNumber(d: Date): number {
+  // Round to nearest day so DST shifts don't break the AP check.
+  return Math.round(d.getTime() / MS_PER_DAY);
+}
+
+function tryListPattern(strs: readonly string[], list: readonly string[]): number[] | null {
+  const indices: number[] = [];
+  for (const s of strs) {
+    const i = findInList(list, s);
+    if (i === -1) return null;
+    indices.push(i);
+  }
+  if (arithmeticStep(indices) === null) return null;
+  return indices;
+}
+
+const PREFIX_NUM_RE = /^(.*?)(-?\d+)$/;
+
+interface PrefixNumParsed {
+  prefix: string;
+  nums: number[];
+}
+
+function tryPrefixNumber(strs: readonly string[]): PrefixNumParsed | null {
+  if (strs.length < 2) return null;
+  let prefix: string | null = null;
+  const nums: number[] = [];
+  for (const s of strs) {
+    const m = PREFIX_NUM_RE.exec(s);
+    if (!m) return null;
+    const p = m[1];
+    const n = Number(m[2]);
+    if (!Number.isFinite(n)) return null;
+    if (prefix === null) prefix = p;
+    else if (prefix !== p) return null;
+    nums.push(n);
+  }
+  if (arithmeticStep(nums) === null) return null;
+  return { prefix: prefix ?? '', nums };
+}
+
+const BUILTIN_LIST_CHECKS: ReadonlyArray<{
+  list: readonly string[];
+  kind: FillPatternKind;
+}> = [
+  { list: DAY_NAMES_SHORT, kind: 'day-name-short' },
+  { list: DAY_NAMES_LONG, kind: 'day-name-long' },
+  { list: MONTH_NAMES_SHORT, kind: 'month-name-short' },
+  { list: MONTH_NAMES_LONG, kind: 'month-name-long' },
+];
+
+// ─── Pattern detection ─────────────────────────────────────
+
+function detectPattern(
+  values: readonly CellValue[],
+  customLists: readonly (readonly string[])[],
+): FillPattern {
+  const n = values.length;
+  if (n === 0) return { kind: 'copy', values };
+
+  // A single seed can still be extended if it belongs to a known list (Excel
+  // treats "Mon" or "Jan" as a sequence even without neighboring cells). For
+  // any other type of single value, cycling the copy is the correct default.
+  if (n === 1) {
+    const only = values[0];
+    if (typeof only === 'string') {
+      if (findInList(DAY_NAMES_SHORT, only) !== -1) return { kind: 'day-name-short', values };
+      if (findInList(DAY_NAMES_LONG, only) !== -1) return { kind: 'day-name-long', values };
+      if (findInList(MONTH_NAMES_SHORT, only) !== -1) return { kind: 'month-name-short', values };
+      if (findInList(MONTH_NAMES_LONG, only) !== -1) return { kind: 'month-name-long', values };
+      for (const list of customLists) {
+        if (findInList(list, only) !== -1) return { kind: 'custom-list', values };
+      }
+    }
+    return { kind: 'copy', values };
+  }
+
+  // Arithmetic over numbers.
+  if (values.every((v) => typeof v === 'number' && Number.isFinite(v))) {
+    const nums = values as readonly number[];
+    const step = arithmeticStep(nums);
+    if (step !== null && step !== 0) return { kind: 'arithmetic', values };
+    return { kind: 'copy', values };
+  }
+
+  // Arithmetic over Date values (day-level).
+  if (values.every((v) => v instanceof Date && !Number.isNaN((v as Date).getTime()))) {
+    const days = (values as readonly Date[]).map(dateToDayNumber);
+    const step = arithmeticStep(days);
+    if (step !== null && step !== 0) return { kind: 'date-day', values };
+    return { kind: 'copy', values };
+  }
+
+  // String-based patterns.
+  if (values.every((v) => typeof v === 'string')) {
+    const strs = values as readonly string[];
+
+    for (const { list, kind } of BUILTIN_LIST_CHECKS) {
+      if (tryListPattern(strs, list)) return { kind, values };
+    }
+    for (const list of customLists) {
+      if (tryListPattern(strs, list)) return { kind: 'custom-list', values };
+    }
+
+    if (tryPrefixNumber(strs)) return { kind: 'prefix-number', values };
+
+    return { kind: 'copy', values };
+  }
+
+  return { kind: 'copy', values };
+}
+
+// ─── Value extrapolation ───────────────────────────────────
+
+function resolveListForKind(
+  kind: FillPatternKind,
+  values: readonly CellValue[],
+  customLists: readonly (readonly string[])[],
+): readonly string[] | null {
+  switch (kind) {
+    case 'day-name-short':
+      return DAY_NAMES_SHORT;
+    case 'day-name-long':
+      return DAY_NAMES_LONG;
+    case 'month-name-short':
+      return MONTH_NAMES_SHORT;
+    case 'month-name-long':
+      return MONTH_NAMES_LONG;
+    case 'custom-list': {
+      // Pick the first registered list that matches the seed — avoids
+      // cross-contamination when multiple lists happen to share a value.
+      const strs = values as readonly string[];
+      for (const list of customLists) {
+        if (tryListPattern(strs, list)) return list;
+      }
+      return null;
+    }
+    default:
+      return null;
+  }
+}
+
+function mod(n: number, m: number): number {
+  return ((n % m) + m) % m;
+}
+
+function extrapolate(
+  pattern: FillPattern,
+  count: number,
+  direction: FillDirection,
+  customLists: readonly (readonly string[])[],
+): CellValue[] {
+  if (count <= 0) return [];
+  const { kind, values } = pattern;
+  const n = values.length;
+  if (n === 0) return [];
+
+  if (kind === 'copy') {
+    const out: CellValue[] = [];
+    for (let i = 0; i < count; i++) {
+      const k = direction === 'forward' ? i : -1 - i;
+      out.push(values[mod(k, n)]);
+    }
+    return out;
+  }
+
+  if (kind === 'arithmetic') {
+    const nums = values as readonly number[];
+    const step = (nums[n - 1] - nums[0]) / (n - 1);
+    const base = direction === 'forward' ? nums[n - 1] : nums[0];
+    const sign = direction === 'forward' ? 1 : -1;
+    const out: CellValue[] = [];
+    for (let i = 0; i < count; i++) {
+      out.push(base + sign * step * (i + 1));
+    }
+    return out;
+  }
+
+  if (kind === 'date-day') {
+    const dates = values as readonly Date[];
+    const days = dates.map(dateToDayNumber);
+    const step = (days[n - 1] - days[0]) / (n - 1);
+    const base = direction === 'forward' ? days[n - 1] : days[0];
+    const sign = direction === 'forward' ? 1 : -1;
+    const out: CellValue[] = [];
+    for (let i = 0; i < count; i++) {
+      const d = Math.round(base + sign * step * (i + 1));
+      out.push(new Date(d * MS_PER_DAY));
+    }
+    return out;
+  }
+
+  if (
+    kind === 'day-name-short' ||
+    kind === 'day-name-long' ||
+    kind === 'month-name-short' ||
+    kind === 'month-name-long' ||
+    kind === 'custom-list'
+  ) {
+    const list = resolveListForKind(kind, values, customLists);
+    // Degenerate: list lookup lost its match (shouldn't happen in practice —
+    // detection and extrapolation use the same registry). Fall back to copy.
+    if (!list) return extrapolate({ kind: 'copy', values }, count, direction, customLists);
+    const strs = values as readonly string[];
+    const indices = strs.map((s) => findInList(list, s));
+    const step = n === 1 ? 1 : (indices[n - 1] - indices[0]) / (n - 1);
+    const base = direction === 'forward' ? indices[n - 1] : indices[0];
+    const sign = direction === 'forward' ? 1 : -1;
+    const L = list.length;
+    const out: CellValue[] = [];
+    for (let i = 0; i < count; i++) {
+      const raw = base + sign * step * (i + 1);
+      out.push(list[mod(Math.round(raw), L)]);
+    }
+    return out;
+  }
+
+  if (kind === 'prefix-number') {
+    const strs = values as readonly string[];
+    const parsed = tryPrefixNumber(strs);
+    if (!parsed) return extrapolate({ kind: 'copy', values }, count, direction, customLists);
+    const { prefix, nums } = parsed;
+    const step = (nums[n - 1] - nums[0]) / (n - 1);
+    const base = direction === 'forward' ? nums[n - 1] : nums[0];
+    const sign = direction === 'forward' ? 1 : -1;
+    const out: CellValue[] = [];
+    for (let i = 0; i < count; i++) {
+      const v = Math.round(base + sign * step * (i + 1));
+      out.push(`${prefix}${v}`);
+    }
+    return out;
+  }
+
+  return [];
+}
+
+// ─── Range resolution ──────────────────────────────────────
+
+interface ResolvedRect {
+  r0: number;
+  r1: number;
+  c0: number;
+  c1: number;
+  startColId: string;
+  endColId: string;
+}
+
+function resolveRect(range: CellRange, colIndex: Map<string, number>): ResolvedRect | null {
+  const a = colIndex.get(range.startCol);
+  const b = colIndex.get(range.endCol);
+  if (a === undefined || b === undefined) return null;
+  const c0 = Math.min(a, b);
+  const c1 = Math.max(a, b);
+  const r0 = Math.min(range.startRow, range.endRow);
+  const r1 = Math.max(range.startRow, range.endRow);
+  return {
+    r0,
+    r1,
+    c0,
+    c1,
+    startColId: range.startCol,
+    endColId: range.endCol,
+  };
+}
+
+// ─── Plugin ────────────────────────────────────────────────
+
+export function createFillHandlePlugin(options: FillHandlePluginOptions = {}): GridPlugin {
+  const customLists: string[][] = (options.customLists ?? []).map((l) => [...l]);
+
+  const plugin: GridPlugin = {
+    name: 'fill-handle',
+
+    init(ctx) {
+      const columnsOf = (): readonly ColumnDef[] => ctx.grid.columns.get();
+
+      const inferPattern: FillHandlePluginApi['inferPattern'] = (values) =>
+        detectPattern(values, customLists);
+
+      const generateValues: FillHandlePluginApi['generateValues'] = (source, count, direction) => {
+        const pattern = detectPattern(source, customLists);
+        return extrapolate(pattern, count, direction, customLists);
+      };
+
+      const fill: FillHandlePluginApi['fill'] = (op: FillOperation) => {
+        const cols = columnsOf();
+        const colIndex = new Map<string, number>();
+        for (let i = 0; i < cols.length; i++) colIndex.set(cols[i].id, i);
+
+        const source = resolveRect(op.source, colIndex);
+        const target = resolveRect(op.target, colIndex);
+        if (!source || !target) return false;
+
+        // Target must fully contain source; extension happens on exactly one
+        // axis. Two-axis drags are ambiguous — Excel rejects them too.
+        if (target.r0 > source.r0 || target.r1 < source.r1) return false;
+        if (target.c0 > source.c0 || target.c1 < source.c1) return false;
+
+        const extraTop = source.r0 - target.r0;
+        const extraBottom = target.r1 - source.r1;
+        const extraLeft = source.c0 - target.c0;
+        const extraRight = target.c1 - source.c1;
+        const rowExt = extraTop + extraBottom;
+        const colExt = extraLeft + extraRight;
+        if (rowExt === 0 && colExt === 0) return false;
+        if (rowExt > 0 && colExt > 0) return false;
+
+        const rowCount = ctx.grid.rowCount;
+
+        ctx.grid.batchUpdate(() => {
+          if (rowExt > 0) {
+            // Row-axis fill: each source column is an independent seed.
+            for (let ci = source.c0; ci <= source.c1; ci++) {
+              const col = cols[ci];
+              if (!col || col.editable === false) continue;
+              const seed: CellValue[] = [];
+              for (let r = source.r0; r <= source.r1; r++) {
+                seed.push(ctx.grid.getCell(r, col.id));
+              }
+              if (extraBottom > 0) {
+                const vs = generateValues(seed, extraBottom, 'forward');
+                for (let i = 0; i < vs.length; i++) {
+                  const row = source.r1 + 1 + i;
+                  if (row < 0 || row >= rowCount) continue;
+                  ctx.grid.setCell(row, col.id, vs[i]);
+                }
+              }
+              if (extraTop > 0) {
+                const vs = generateValues(seed, extraTop, 'reverse');
+                for (let i = 0; i < vs.length; i++) {
+                  const row = source.r0 - 1 - i;
+                  if (row < 0 || row >= rowCount) continue;
+                  ctx.grid.setCell(row, col.id, vs[i]);
+                }
+              }
+            }
+          } else {
+            // Column-axis fill: each source row is an independent seed.
+            for (let r = source.r0; r <= source.r1; r++) {
+              const seed: CellValue[] = [];
+              for (let ci = source.c0; ci <= source.c1; ci++) {
+                const col = cols[ci];
+                seed.push(col ? ctx.grid.getCell(r, col.id) : null);
+              }
+              if (extraRight > 0) {
+                const vs = generateValues(seed, extraRight, 'forward');
+                for (let i = 0; i < vs.length; i++) {
+                  const col = cols[source.c1 + 1 + i];
+                  if (!col || col.editable === false) continue;
+                  ctx.grid.setCell(r, col.id, vs[i]);
+                }
+              }
+              if (extraLeft > 0) {
+                const vs = generateValues(seed, extraLeft, 'reverse');
+                for (let i = 0; i < vs.length; i++) {
+                  const col = cols[source.c0 - 1 - i];
+                  if (!col || col.editable === false) continue;
+                  ctx.grid.setCell(r, col.id, vs[i]);
+                }
+              }
+            }
+          }
+        });
+        return true;
+      };
+
+      const api: FillHandlePluginApi = {
+        fill,
+        inferPattern,
+        generateValues,
+        registerCustomList(list) {
+          customLists.push([...list]);
+        },
+        getCustomLists() {
+          return customLists.map((l) => [...l]);
+        },
+      };
+
+      ctx.expose('fill-handle', api);
+
+      // No event listeners today — the plugin is driven entirely by caller
+      // invocation. Returning a no-op cleanup keeps parity with the other
+      // plugins so future additions (e.g. preview decorators) don't leak.
+      return () => {
+        /* noop */
+      };
+    },
+  };
+
+  return plugin;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,9 @@ export { createClipboardPlugin } from './clipboard';
 // History
 export { createHistoryPlugin } from './history';
 
+// Fill Handle
+export { createFillHandlePlugin } from './fill-handle';
+
 // Column grouping
 export {
   flattenColumns,
@@ -79,6 +82,12 @@ export type {
   Command,
   HistoryPluginApi,
   HistoryPluginOptions,
+  FillPatternKind,
+  FillDirection,
+  FillPattern,
+  FillOperation,
+  FillHandlePluginOptions,
+  FillHandlePluginApi,
   CellDecoration,
   CellDecorator,
   PluginContext,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -296,6 +296,75 @@ export interface ClipboardPluginApi {
   applyMatrix(matrix: ClipboardMatrix, startRow: number, startCol: string): void;
 }
 
+// ─── Fill Handle ──────────────────────────────────────────
+
+/**
+ * Recognizable series a source block can follow. `copy` is the fallback when
+ * no other pattern fits — the seed values cycle unchanged.
+ */
+export type FillPatternKind =
+  | 'copy'
+  | 'arithmetic'
+  | 'date-day'
+  | 'day-name-short'
+  | 'day-name-long'
+  | 'month-name-short'
+  | 'month-name-long'
+  | 'custom-list'
+  | 'prefix-number';
+
+/** Direction of extrapolation relative to the seed block. */
+export type FillDirection = 'forward' | 'reverse';
+
+/** Detected pattern over a 1-D sequence of seed values. */
+export interface FillPattern {
+  kind: FillPatternKind;
+  /** The original seed values, unchanged. */
+  values: readonly CellValue[];
+}
+
+export interface FillOperation {
+  /** The block of seed cells. */
+  source: CellRange;
+  /**
+   * The rectangle after the drag. Must fully contain `source` and extend in
+   * exactly one axis (rows OR columns), never both.
+   */
+  target: CellRange;
+}
+
+export interface FillHandlePluginOptions {
+  /**
+   * Case-insensitive cyclic lists the pattern detector will recognize
+   * (e.g. `['Q1','Q2','Q3','Q4']`). Day/month name lists are built in and
+   * do not need to be registered here.
+   */
+  customLists?: readonly (readonly string[])[];
+}
+
+export interface FillHandlePluginApi {
+  /**
+   * Apply a fill. Returns `true` when cells were written; `false` for degenerate
+   * inputs (empty source, target not containing source, two-axis extension).
+   */
+  fill(op: FillOperation): boolean;
+  /** Detect the pattern over a 1-D seed sequence. */
+  inferPattern(values: readonly CellValue[]): FillPattern;
+  /**
+   * Extrapolate `count` values from a seed sequence. `forward` continues the
+   * pattern past the end; `reverse` extends backward past the start.
+   */
+  generateValues(
+    source: readonly CellValue[],
+    count: number,
+    direction: FillDirection,
+  ): CellValue[];
+  /** Add a custom cyclic list for the detector to recognize from now on. */
+  registerCustomList(list: readonly string[]): void;
+  /** Snapshot of every custom list currently registered (in registration order). */
+  getCustomLists(): string[][];
+}
+
 // ─── History ──────────────────────────────────────────────
 
 /**

--- a/packages/react/src/fill-handle.spec.tsx
+++ b/packages/react/src/fill-handle.spec.tsx
@@ -1,0 +1,149 @@
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Grid } from './grid';
+import type { GridColumnDef } from './types';
+
+// ─── DOM mocks ─────────────────────────────────────────────
+
+const origCW = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+const origCH = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+
+beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    get() {
+      return 600;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    get() {
+      return 400;
+    },
+  });
+
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+afterEach(() => {
+  if (origCW) Object.defineProperty(HTMLElement.prototype, 'clientWidth', origCW);
+  if (origCH) Object.defineProperty(HTMLElement.prototype, 'clientHeight', origCH);
+  vi.restoreAllMocks();
+});
+
+// ─── Fixtures ──────────────────────────────────────────────
+
+const columns: GridColumnDef[] = [
+  { id: 'a', header: 'A', type: 'number' },
+  { id: 'b', header: 'B', type: 'number' },
+  { id: 'c', header: 'C', type: 'number' },
+];
+
+function data(rows: number) {
+  const out: Array<Record<string, number | null>> = [];
+  for (let i = 0; i < rows; i++) out.push({ a: null, b: null, c: null });
+  return out;
+}
+
+function findCell(row: number, col: string): HTMLElement {
+  const el = document.querySelector(`[data-row="${row}"][data-col="${col}"]`);
+  if (!el) throw new Error(`cell (${row}, ${col}) not found`);
+  return el as HTMLElement;
+}
+
+function getFillHandle(): HTMLElement | null {
+  return document.querySelector('.gs-fill-handle') as HTMLElement | null;
+}
+
+describe('Grid fill handle', () => {
+  it('renders the fill handle when a selection exists', () => {
+    render(<Grid data={data(4)} columns={columns} />);
+    expect(getFillHandle()).toBeNull();
+    fireEvent.mouseDown(findCell(0, 'a'), { button: 0 });
+    fireEvent.mouseUp(findCell(0, 'a'));
+    expect(getFillHandle()).not.toBeNull();
+  });
+
+  it('hides the handle during editing', () => {
+    render(<Grid data={data(4)} columns={columns} />);
+    fireEvent.mouseDown(findCell(0, 'a'), { button: 0 });
+    fireEvent.mouseUp(findCell(0, 'a'));
+    expect(getFillHandle()).not.toBeNull();
+    // Enter edit mode via double-click.
+    fireEvent.doubleClick(findCell(0, 'a'));
+    expect(getFillHandle()).toBeNull();
+  });
+
+  it('fills a numeric series down when dragging to a lower row', () => {
+    const initial = [{ a: 1 }, { a: 2 }, { a: null }, { a: null }, { a: null }];
+    const onCellChange = vi.fn();
+    render(
+      <Grid
+        data={initial}
+        columns={[{ id: 'a', header: 'A', type: 'number' }]}
+        onCellChange={onCellChange}
+      />,
+    );
+
+    // Select rows 0–1 in column 'a'. `buttons: 1` is required — the drag
+    // extender bails when the primary button isn't held.
+    fireEvent.mouseDown(findCell(0, 'a'), { button: 0 });
+    fireEvent.mouseMove(findCell(1, 'a'), { buttons: 1 });
+    fireEvent.mouseUp(findCell(1, 'a'));
+
+    const handle = getFillHandle();
+    expect(handle).not.toBeNull();
+
+    // Drag the handle down to row 4. jsdom does not implement
+    // `document.elementFromPoint`, so we define it ourselves for the test.
+    const targetCell = findCell(4, 'a');
+    (
+      document as unknown as { elementFromPoint: (x: number, y: number) => Element | null }
+    ).elementFromPoint = () => targetCell;
+
+    fireEvent.pointerDown(handle!, { button: 0, pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(handle!, { pointerId: 1, clientX: 0, clientY: 200 });
+    fireEvent.pointerUp(handle!, { pointerId: 1, clientX: 0, clientY: 200 });
+
+    // Rows 2, 3, 4 should have been filled with 3, 4, 5.
+    const changes = onCellChange.mock.calls.map((c) => c[0]);
+    const byRow = new Map<number, unknown>();
+    for (const c of changes) byRow.set(c.row, c.newValue);
+    expect(byRow.get(2)).toBe(3);
+    expect(byRow.get(3)).toBe(4);
+    expect(byRow.get(4)).toBe(5);
+  });
+
+  it('does not apply a fill when the pointer never left the source', () => {
+    const initial = [{ a: 10 }, { a: null }];
+    const onCellChange = vi.fn();
+    render(
+      <Grid
+        data={initial}
+        columns={[{ id: 'a', header: 'A', type: 'number' }]}
+        onCellChange={onCellChange}
+      />,
+    );
+    fireEvent.mouseDown(findCell(0, 'a'), { button: 0 });
+    fireEvent.mouseUp(findCell(0, 'a'));
+
+    const handle = getFillHandle()!;
+    const sourceCell = findCell(0, 'a');
+    (
+      document as unknown as { elementFromPoint: (x: number, y: number) => Element | null }
+    ).elementFromPoint = () => sourceCell;
+
+    fireEvent.pointerDown(handle, { button: 0, pointerId: 1, clientX: 0, clientY: 0 });
+    fireEvent.pointerUp(handle, { pointerId: 1, clientX: 0, clientY: 0 });
+
+    expect(onCellChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/grid.tsx
+++ b/packages/react/src/grid.tsx
@@ -1,8 +1,10 @@
 import {
+  type CellRange,
   type CellValue,
   type ClipboardPluginApi,
   type EditingPluginApi,
   type EditState,
+  type FillHandlePluginApi,
   type FilterEntry,
   type GridInstance,
   type HeaderCell,
@@ -16,6 +18,7 @@ import {
   computeColumnLayout,
   createClipboardPlugin,
   createEditingPlugin,
+  createFillHandlePlugin,
   createHistoryPlugin,
   createSelectionPlugin,
   flattenColumns,
@@ -123,7 +126,14 @@ export const Grid = memo(function Grid({
     const selectionPlugin = createSelectionPlugin();
     const clipboardPlugin = createClipboardPlugin();
     const historyPlugin = createHistoryPlugin();
-    const builtins = [editingPlugin, selectionPlugin, clipboardPlugin, historyPlugin];
+    const fillHandlePlugin = createFillHandlePlugin();
+    const builtins = [
+      editingPlugin,
+      selectionPlugin,
+      clipboardPlugin,
+      historyPlugin,
+      fillHandlePlugin,
+    ];
     return plugins ? [...builtins, ...plugins] : builtins;
   });
 
@@ -210,6 +220,12 @@ export const Grid = memo(function Grid({
   const historyApi = useMemo(() => {
     const api = grid.getPlugin<HistoryPluginApi>('history');
     if (!api) throw new Error('History plugin not found — this should not happen');
+    return api;
+  }, [grid]);
+
+  const fillHandleApi = useMemo(() => {
+    const api = grid.getPlugin<FillHandlePluginApi>('fill-handle');
+    if (!api) throw new Error('Fill handle plugin not found — this should not happen');
     return api;
   }, [grid]);
 
@@ -996,6 +1012,205 @@ export const Grid = memo(function Grid({
     dragSelectRef.current = null;
   }, []);
 
+  // ─── Fill handle ───────────────────────────────────────
+  //
+  // Rect of the range that owns the fill handle — the last range in the
+  // selection (matches the clipboard plugin's "active range" rule). Returned
+  // as canvas-relative coords so it composes with the overlay below.
+  const activeRange = useMemo<CellRange | null>(() => {
+    const ranges = selection.ranges;
+    if (ranges.length === 0) return null;
+    return ranges[ranges.length - 1];
+  }, [selection.ranges]);
+
+  const rectForRange = useCallback(
+    (range: CellRange): { left: number; top: number; width: number; height: number } | null => {
+      const startIdx = currentColumns.findIndex((c) => c.id === range.startCol);
+      const endIdx = currentColumns.findIndex((c) => c.id === range.endCol);
+      if (startIdx === -1 || endIdx === -1) return null;
+      const c0 = Math.min(startIdx, endIdx);
+      const c1 = Math.max(startIdx, endIdx);
+      const r0 = Math.min(range.startRow, range.endRow);
+      const r1 = Math.max(range.startRow, range.endRow);
+      const left = columnLayout.offsets[c0] ?? 0;
+      const rightCol = c1;
+      const right = (columnLayout.offsets[rightCol] ?? 0) + (columnLayout.widths[rightCol] ?? 0);
+      const top = r0 * rowHeight;
+      const bottom = (r1 + 1) * rowHeight;
+      return { left, top, width: right - left, height: bottom - top };
+    },
+    [currentColumns, columnLayout, rowHeight],
+  );
+
+  const activeRangeRect = useMemo(
+    () => (activeRange ? rectForRange(activeRange) : null),
+    [activeRange, rectForRange],
+  );
+
+  const [fillPreviewRange, setFillPreviewRange] = useState<CellRange | null>(null);
+  const fillPreviewRect = useMemo(
+    () => (fillPreviewRange ? rectForRange(fillPreviewRange) : null),
+    [fillPreviewRange, rectForRange],
+  );
+
+  /**
+   * Drag state set on pointerdown at the fill handle. `sourceRange` is
+   * captured up-front so later selection mutations (e.g. stray clicks) don't
+   * change the seed mid-drag.
+   */
+  const fillDragRef = useRef<{
+    pointerId: number;
+    sourceRange: CellRange;
+    targetRange: CellRange;
+  } | null>(null);
+
+  /**
+   * Given a pointer, find the cell under it. Returns `null` when the pointer
+   * is outside any rendered cell (headers, empty viewport space). Uses
+   * `elementFromPoint` + a data-attribute read rather than tracking the last
+   * hovered cell — simpler, and correct even when the pointer re-enters from
+   * an unexpected edge.
+   */
+  const lookupCellAt = useCallback(
+    (clientX: number, clientY: number): { row: number; col: string } | null => {
+      const el = document.elementFromPoint(clientX, clientY);
+      if (!el) return null;
+      const cellEl = (el as HTMLElement).closest?.('.gs-cell') as HTMLElement | null;
+      if (!cellEl) return null;
+      const row = Number(cellEl.dataset.row);
+      const col = cellEl.dataset.col;
+      if (col == null || Number.isNaN(row)) return null;
+      return { row, col };
+    },
+    [],
+  );
+
+  /**
+   * Given the source range and a target cell, expand the source to a target
+   * rectangle constrained to a single axis. The axis is chosen by whichever
+   * direction the pointer moved further from the source's nearest edge.
+   */
+  const computeFillTarget = useCallback(
+    (source: CellRange, cell: { row: number; col: string }): CellRange => {
+      const startIdx = currentColumns.findIndex((c) => c.id === source.startCol);
+      const endIdx = currentColumns.findIndex((c) => c.id === source.endCol);
+      const targetIdx = currentColumns.findIndex((c) => c.id === cell.col);
+      if (startIdx === -1 || endIdx === -1 || targetIdx === -1) return source;
+
+      const srcC0 = Math.min(startIdx, endIdx);
+      const srcC1 = Math.max(startIdx, endIdx);
+      const srcR0 = Math.min(source.startRow, source.endRow);
+      const srcR1 = Math.max(source.startRow, source.endRow);
+
+      // Row-distance from the nearest edge of the source block.
+      const rowOverflow =
+        cell.row < srcR0 ? srcR0 - cell.row : cell.row > srcR1 ? cell.row - srcR1 : 0;
+      const colOverflow =
+        targetIdx < srcC0 ? srcC0 - targetIdx : targetIdx > srcC1 ? targetIdx - srcC1 : 0;
+
+      // Pick the dominant axis. Ties fall through to rows (matches Excel's
+      // slight preference for vertical fills when the pointer sits on a
+      // corner cell).
+      if (rowOverflow === 0 && colOverflow === 0) return source;
+      if (rowOverflow >= colOverflow) {
+        const r0 = Math.min(cell.row, srcR0);
+        const r1 = Math.max(cell.row, srcR1);
+        return {
+          startRow: r0,
+          endRow: r1,
+          startCol: source.startCol,
+          endCol: source.endCol,
+        };
+      }
+      const newC0 = Math.min(targetIdx, srcC0);
+      const newC1 = Math.max(targetIdx, srcC1);
+      return {
+        startRow: source.startRow,
+        endRow: source.endRow,
+        startCol: currentColumns[newC0].id,
+        endCol: currentColumns[newC1].id,
+      };
+    },
+    [currentColumns],
+  );
+
+  const handleFillHandlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      // Ignore non-primary buttons (right-click, middle-click). jsdom
+      // synthetic events can leave `button` unset — treat that as primary.
+      const button = (e as unknown as { button?: number }).button ?? 0;
+      if (button !== 0) return;
+      if (!activeRange) return;
+      e.preventDefault();
+      e.stopPropagation();
+      // `setPointerCapture` throws in jsdom test environments that lack
+      // layout tracking — swallow the error so the drag still proceeds.
+      try {
+        (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+      } catch {
+        /* noop */
+      }
+      fillDragRef.current = {
+        pointerId: e.pointerId,
+        sourceRange: activeRange,
+        targetRange: activeRange,
+      };
+      setFillPreviewRange(activeRange);
+    },
+    [activeRange],
+  );
+
+  const handleFillHandlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const drag = fillDragRef.current;
+      if (!drag) return;
+      const cell = lookupCellAt(e.clientX, e.clientY);
+      if (!cell) return;
+      const target = computeFillTarget(drag.sourceRange, cell);
+      drag.targetRange = target;
+      setFillPreviewRange(target);
+    },
+    [lookupCellAt, computeFillTarget],
+  );
+
+  const handleFillHandlePointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const drag = fillDragRef.current;
+      if (!drag) return;
+      try {
+        (e.currentTarget as HTMLElement).releasePointerCapture(drag.pointerId);
+      } catch {
+        // Capture may already be lost (e.g. element unmounted) — safe to ignore.
+      }
+      fillDragRef.current = null;
+      setFillPreviewRange(null);
+      // Only apply when the target actually extended the source — a click
+      // without drag produces an identical rectangle and shouldn't mutate.
+      const same =
+        drag.targetRange.startRow === drag.sourceRange.startRow &&
+        drag.targetRange.endRow === drag.sourceRange.endRow &&
+        drag.targetRange.startCol === drag.sourceRange.startCol &&
+        drag.targetRange.endCol === drag.sourceRange.endCol;
+      if (same) return;
+      fillHandleApi.fill({ source: drag.sourceRange, target: drag.targetRange });
+      // Expand the selection to include the newly filled region so the user
+      // can continue acting on the extended block.
+      selectionApi.selectCell({
+        row: drag.targetRange.startRow,
+        col: drag.targetRange.startCol,
+      });
+      selectionApi.extendTo({
+        row: drag.targetRange.endRow,
+        col: drag.targetRange.endCol,
+      });
+    },
+    [fillHandleApi, selectionApi],
+  );
+
+  // Hide the handle while editing or when the active range references a
+  // column that has since been removed.
+  const fillHandleVisible = !editState && activeRangeRect !== null;
+
   const handleCellClick = useCallback(
     (e: React.MouseEvent) => {
       const cell = parseCellFromTarget(e.target);
@@ -1569,6 +1784,47 @@ export const Grid = memo(function Grid({
         >
           {rowElements}
           {editorOverlay}
+          {fillPreviewRect && (
+            <div
+              className="gs-fill-preview"
+              aria-hidden="true"
+              style={{
+                position: 'absolute',
+                left: fillPreviewRect.left,
+                top: fillPreviewRect.top,
+                width: fillPreviewRect.width,
+                height: fillPreviewRect.height,
+                border: '1px dashed #1a73e8',
+                boxSizing: 'border-box',
+                pointerEvents: 'none',
+                zIndex: 4,
+              }}
+            />
+          )}
+          {fillHandleVisible && activeRangeRect && (
+            <div
+              className="gs-fill-handle"
+              role="presentation"
+              aria-hidden="true"
+              onPointerDown={handleFillHandlePointerDown}
+              onPointerMove={handleFillHandlePointerMove}
+              onPointerUp={handleFillHandlePointerUp}
+              onPointerCancel={handleFillHandlePointerUp}
+              style={{
+                position: 'absolute',
+                left: activeRangeRect.left + activeRangeRect.width - 4,
+                top: activeRangeRect.top + activeRangeRect.height - 4,
+                width: 8,
+                height: 8,
+                background: '#1a73e8',
+                border: '1px solid white',
+                boxSizing: 'border-box',
+                cursor: 'crosshair',
+                zIndex: 5,
+                touchAction: 'none',
+              }}
+            />
+          )}
         </div>
       </div>
       {pinnedBottomRowsEl}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,6 +8,7 @@ export { useSignalValue } from './use-signal';
 export { useGridSelection } from './use-grid-selection';
 export type { SelectionState } from './use-grid-selection';
 export { useGridClipboard } from './use-grid-clipboard';
+export { useGridFillHandle } from './use-grid-fill-handle';
 
 // Types
 export type { GridProps, GridColumnDef, CellRendererProps, CellEditorProps } from './types';
@@ -42,8 +43,15 @@ export {
   type Command,
   type HistoryPluginApi,
   type HistoryPluginOptions,
+  type FillPatternKind,
+  type FillDirection,
+  type FillPattern,
+  type FillOperation,
+  type FillHandlePluginOptions,
+  type FillHandlePluginApi,
   createClipboardPlugin,
   createEditingPlugin,
+  createFillHandlePlugin,
   createHistoryPlugin,
   flattenColumns,
   getHeaderDepth,

--- a/packages/react/src/use-grid-fill-handle.ts
+++ b/packages/react/src/use-grid-fill-handle.ts
@@ -1,0 +1,10 @@
+import type { FillHandlePluginApi, GridInstance } from '@gridsmith/core';
+import { useMemo } from 'react';
+
+/**
+ * Read the fill-handle plugin API off a grid instance. Returns the same
+ * reference across renders for stable callback identities.
+ */
+export function useGridFillHandle(grid: GridInstance): FillHandlePluginApi | null {
+  return useMemo(() => grid.getPlugin<FillHandlePluginApi>('fill-handle') ?? null, [grid]);
+}

--- a/packages/react/src/use-grid-plugins.spec.tsx
+++ b/packages/react/src/use-grid-plugins.spec.tsx
@@ -1,0 +1,33 @@
+import {
+  createClipboardPlugin,
+  createFillHandlePlugin,
+  createGrid,
+  createSelectionPlugin,
+} from '@gridsmith/core';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useGridClipboard } from './use-grid-clipboard';
+import { useGridFillHandle } from './use-grid-fill-handle';
+
+describe('plugin accessor hooks', () => {
+  it('returns the plugin api when registered', () => {
+    const grid = createGrid({
+      data: [{ a: null }],
+      columns: [{ id: 'a', header: 'A', type: 'text' }],
+      plugins: [createSelectionPlugin(), createClipboardPlugin(), createFillHandlePlugin()],
+    });
+    expect(renderHook(() => useGridClipboard(grid)).result.current).not.toBeNull();
+    expect(renderHook(() => useGridFillHandle(grid)).result.current).not.toBeNull();
+  });
+
+  it('returns null when the plugin is not registered', () => {
+    const grid = createGrid({
+      data: [{ a: null }],
+      columns: [{ id: 'a', header: 'A', type: 'text' }],
+      plugins: [],
+    });
+    expect(renderHook(() => useGridClipboard(grid)).result.current).toBeNull();
+    expect(renderHook(() => useGridFillHandle(grid)).result.current).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `createFillHandlePlugin` to `@gridsmith/core` with pattern recognition for arithmetic, day/month names, dates, prefix-number, custom lists, and copy fallback.
- React adapter auto-registers the plugin and renders an 8×8 drag handle at the active range's bottom-right with a dashed preview rect during drag.
- Exposes `useGridFillHandle(grid)` hook alongside the existing `useGridClipboard` / `useGridSelection` accessors.

## Test plan

- [x] `pnpm turbo test` — 332 core tests, 179 react tests green
- [x] `pnpm turbo type-check` — clean
- [x] Branch coverage above 80% threshold on both packages
- [ ] Playground smoke: drag handle fills numeric series, day names, and custom lists correctly
- [ ] Undo/redo restores the pre-fill state in a single step
- [ ] Handle hides while editing and during row-level range selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)