### PR TITLE
feat: cell validation — sync/async validators, visual indicators (#14)

### DIFF
--- a/.changeset/cell-validation.md
+++ b/.changeset/cell-validation.md
@@ -1,0 +1,55 @@
+---
+'@gridsmith/core': minor
+'@gridsmith/react': minor
+---
+
+Add cell validation with sync/async validators and visual indicators.
+
+**Core (`@gridsmith/core`):**
+
+- New `createValidationPlugin()` exports a `'validation'` plugin that
+  records per-cell validation errors keyed by stable data index, so
+  errors survive sort/filter/reorder.
+- Columns can declare a sync `validate(value, ctx)` and/or an async
+  `asyncValidate(value, ctx)`. A validator returns `true` for pass or
+  a string message for fail.
+- `validationMode: 'reject' | 'warn'` (default `reject`) controls
+  commit behavior. In `reject`, a sync failure aborts the commit and
+  the cell keeps its pre-edit value (the cell stays decorated only if
+  that pre-edit value is itself invalid). In `warn`, the value commits
+  and the error is decorated on the cell.
+- The editing plugin calls `validateCell` before `setCell` so a
+  rejected commit never touches grid data.
+- `validateCellAsync` marks the cell as pending, applies the result
+  on resolution, and discards stale results when newer validation
+  runs supersede an in-flight one (token-based cancellation).
+- Listens to `data:change` so programmatic writes (clipboard paste,
+  fill handle, direct `setCell`) also trigger re-validation against
+  the column's declared validators.
+- `validateAll()` walks every row × validating column (including
+  filtered-out rows, keyed by data-index) and returns the resulting
+  error list. `clearErrors(rowIndex?, columnId?)` clears at global,
+  row, column, or single-cell scope depending on which args are passed.
+- Emits `'validation:change'` with the new error list whenever the
+  error map changes, so adapters can react in a single place.
+- Cell decorator adds `gs-cell--invalid` (with `title`,
+  `data-validation-state`, `data-validation-message` attributes) and
+  `gs-cell--validating` for pending async runs.
+- New types: `ValidationResult`, `ValidationContext`, `SyncValidator`,
+  `AsyncValidator`, `ValidationMode`, `ValidationErrorState`,
+  `ValidationError`, `ValidationPluginApi`.
+
+**React (`@gridsmith/react`):**
+
+- Auto-registers the validation plugin alongside editing, selection,
+  clipboard, history, and fill-handle.
+- Subscribes to `'validation:change'` so cells re-render with the
+  invalid/validating decoration and tooltip the moment validation
+  state changes.
+- New `useGridValidation(grid)` hook returns the plugin API (or
+  `null` if not registered) for callers that want to inspect errors
+  or trigger validation programmatically.
+- Re-exports `createValidationPlugin`, `ValidationPluginApi`,
+  `ValidationResult`, `ValidationContext`, `ValidationMode`,
+  `ValidationErrorState`, `ValidationError`, `SyncValidator`, and
+  `AsyncValidator`.

--- a/apps/playground/index.html
+++ b/apps/playground/index.html
@@ -4,6 +4,15 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Gridsmith Playground</title>
+    <style>
+      .gs-cell--invalid {
+        box-shadow: inset 0 0 0 2px #dc2626;
+        background: #fef2f2;
+      }
+      .gs-cell--validating {
+        box-shadow: inset 0 0 0 2px #f59e0b;
+      }
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/playground/src/main.tsx
+++ b/apps/playground/src/main.tsx
@@ -11,8 +11,21 @@ import { createRoot } from 'react-dom/client';
 
 const sampleColumns: GridColumnDef[] = [
   { id: 'id', header: '#', width: 60, pin: 'left', editable: false, sortable: false },
-  { id: 'name', header: 'Name', width: 150, type: 'text' },
-  { id: 'age', header: 'Age', width: 80, type: 'number' },
+  {
+    id: 'name',
+    header: 'Name',
+    width: 150,
+    type: 'text',
+    validate: (v) => (typeof v === 'string' && v.length > 0) || 'Name is required',
+  },
+  {
+    id: 'age',
+    header: 'Age',
+    width: 80,
+    type: 'number',
+    validationMode: 'warn',
+    validate: (v) => (typeof v === 'number' && v >= 0 && v < 150) || 'Age must be 0–149',
+  },
   { id: 'city', header: 'City', width: 120, type: 'text' },
   {
     id: 'department',
@@ -66,7 +79,8 @@ function App() {
       <h1 style={{ margin: '0 0 0.5rem' }}>Gridsmith Playground</h1>
       <p style={{ margin: '0 0 1rem', color: '#64748b' }}>
         v{VERSION} — Drag column borders to resize, drag headers to reorder. # and Actions columns
-        are pinned. Rows 0, 1 pinned to top.
+        are pinned. Rows 0, 1 pinned to top. Name is required (reject). Age must be 0–149 (warn —
+        invalid values commit with a red border).
       </p>
       <div
         style={{ flex: 1, border: '1px solid #e2e8f0', borderRadius: '8px', overflow: 'hidden' }}

--- a/packages/core/src/editing.ts
+++ b/packages/core/src/editing.ts
@@ -1,4 +1,11 @@
-import type { CellValue, EditorDefinition, EditingPluginApi, EditState, GridPlugin } from './types';
+import type {
+  CellValue,
+  EditorDefinition,
+  EditingPluginApi,
+  EditState,
+  GridPlugin,
+  ValidationPluginApi,
+} from './types';
 
 const builtinEditors: EditorDefinition[] = [
   {
@@ -91,6 +98,29 @@ export function createEditingPlugin(): GridPlugin {
           let finalValue = value;
           if (typeof value === 'string' && editor?.parse) {
             finalValue = editor.parse(value);
+          }
+
+          // Validation. Only runs when a validation plugin is registered and
+          // the column declares a validator. Sync failures in `reject` mode
+          // abort the commit; `warn` commits the value and leaves the error
+          // recorded by the plugin so the UI can flag it.
+          const validationApi = ctx.getPlugin<ValidationPluginApi>('validation');
+          if (validationApi && (col?.validate || col?.asyncValidate)) {
+            const result = validationApi.validateCell(rowIndex, columnId, finalValue);
+            const mode = col?.validationMode ?? 'reject';
+            if (result !== true && mode === 'reject') {
+              // `validateCell` recorded the transient failure for `finalValue`,
+              // but reject-mode never commits that value — so the recorded
+              // error would mislabel the cell. Resync by revalidating against
+              // the value that actually stays in the cell (the pre-edit one).
+              // If the pre-edit value is itself invalid (e.g. malformed seed
+              // data), the cell remains flagged — intentional, since the cell
+              // really does still hold an invalid value.
+              validationApi.validateCell(rowIndex, columnId, originalValue);
+              editState = null;
+              ctx.events.emit('edit:cancel', { rowIndex, columnId });
+              return false;
+            }
           }
 
           editState = null;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,6 +37,9 @@ export { createHistoryPlugin } from './history';
 // Fill Handle
 export { createFillHandlePlugin } from './fill-handle';
 
+// Validation
+export { createValidationPlugin } from './validation';
+
 // Column grouping
 export {
   flattenColumns,
@@ -88,6 +91,14 @@ export type {
   FillOperation,
   FillHandlePluginOptions,
   FillHandlePluginApi,
+  ValidationResult,
+  ValidationContext,
+  ValidationMode,
+  ValidationErrorState,
+  ValidationError,
+  ValidationPluginApi,
+  SyncValidator,
+  AsyncValidator,
   CellDecoration,
   CellDecorator,
   PluginContext,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -46,6 +46,24 @@ export interface ColumnDef {
   /** Custom comparator for sorting this column. Overrides the default. */
   comparator?: CellComparator;
   /**
+   * Synchronous validator. Return `true` when the value is valid or a string
+   * error message when it isn't. Runs on commit; the result is forwarded to
+   * the validation plugin which records/decorates errors.
+   */
+  validate?: SyncValidator;
+  /**
+   * Asynchronous validator. Runs alongside `validate` (not a fallback). The
+   * cell is flagged `pending` until the promise settles; async failures
+   * never block commit — they only surface as a post-hoc error.
+   */
+  asyncValidate?: AsyncValidator;
+  /**
+   * How a synchronous validation failure is handled on commit.
+   * - `reject` (default): cancel the commit, keep the original value.
+   * - `warn`: accept the value but record the error for UI feedback.
+   */
+  validationMode?: ValidationMode;
+  /**
    * Nested child columns. When set, this entry is treated as a header group:
    * it renders a spanning header cell above its children and does not carry
    * its own data. Data operations (sort/filter/edit) run on leaf columns only.
@@ -162,6 +180,7 @@ export interface GridEvents {
   'transaction:begin': { depth: number };
   'transaction:end': { depth: number };
   'history:change': { canUndo: boolean; canRedo: boolean; undoSize: number; redoSize: number };
+  'validation:change': { errors: readonly ValidationError[] };
   'plugin:ready': { name: string };
   ready: undefined;
   destroy: undefined;
@@ -402,6 +421,96 @@ export interface HistoryPluginApi {
   getUndoSize(): number;
   getRedoSize(): number;
   setMaxSize(size: number): void;
+}
+
+// ─── Validation ───────────────────────────────────────────
+
+/**
+ * Outcome of a single validator. `true` means valid; any string is the error
+ * message to surface. Using a plain string (rather than a rich object) keeps
+ * the return type of most handwritten validators trivial to read.
+ */
+export type ValidationResult = true | string;
+
+/** Context passed to validators at call-time. */
+export interface ValidationContext {
+  /** View-index at validation time. Use `dataIndex` for identity across sort/filter. */
+  rowIndex: number;
+  /** Stable data-index of the row (survives sort and filter). */
+  dataIndex: number;
+  columnId: string;
+  /**
+   * Snapshot of the row at validation time. Reflects the *committed* value of
+   * each cell — the candidate value being validated is passed separately as
+   * the validator's first argument, not via `row[columnId]`.
+   */
+  row: Row;
+  /**
+   * Value the cell held before the edit in progress. For revalidations not
+   * triggered by an edit, equals the cell's current value.
+   */
+  originalValue: CellValue;
+}
+
+export type SyncValidator = (value: CellValue, ctx: ValidationContext) => ValidationResult;
+export type AsyncValidator = (
+  value: CellValue,
+  ctx: ValidationContext,
+) => Promise<ValidationResult>;
+
+/** Determines whether a failing sync validator blocks the commit. */
+export type ValidationMode = 'reject' | 'warn';
+
+/**
+ * `invalid` — a validator returned an error message. `pending` — an async
+ * validator is still running for the cell (no resolved verdict yet).
+ */
+export type ValidationErrorState = 'invalid' | 'pending';
+
+export interface ValidationError {
+  /** Stable data-index of the row (not a view index). */
+  dataIndex: number;
+  columnId: string;
+  /** Error message from the failing validator; empty string while pending. */
+  message: string;
+  value: CellValue;
+  state: ValidationErrorState;
+}
+
+export interface ValidationPluginApi {
+  /**
+   * Run sync validation for the current (or supplied) value of a cell. The
+   * internal error state and cell decoration are updated as a side-effect, and
+   * `'validation:change'` is emitted when the verdict for the cell changes.
+   * Async validators attached to the same column are kicked off in the
+   * background; their resolution updates the error state asynchronously.
+   */
+  validateCell(rowIndex: number, columnId: string, value?: CellValue): ValidationResult;
+  /**
+   * Run sync + async validation and resolve with the async result (or the
+   * sync failure, if sync failed). Cell is flagged `pending` while running.
+   */
+  validateCellAsync(
+    rowIndex: number,
+    columnId: string,
+    value?: CellValue,
+  ): Promise<ValidationResult>;
+  /** Validate every cell that has at least one validator. Resolves with the final error set. */
+  validateAll(): Promise<readonly ValidationError[]>;
+  /** Current error/pending record for a view-cell, or `null` if valid. */
+  getError(rowIndex: number, columnId: string): ValidationError | null;
+  /** `true` if an async validation is still in flight for the cell. */
+  isPending(rowIndex: number, columnId: string): boolean;
+  /** Snapshot of every current error (invalid or pending). */
+  getErrors(): readonly ValidationError[];
+  /**
+   * Drop recorded errors. Scope is selected by which args are passed:
+   * - `()` — clear everything.
+   * - `(rowIndex)` — clear every error on that row.
+   * - `(undefined, columnId)` — clear every error on that column.
+   * - `(rowIndex, columnId)` — clear a single cell.
+   */
+  clearErrors(rowIndex?: number, columnId?: string): void;
 }
 
 // ─── Plugin ────────────────────────────────────────────────

--- a/packages/core/src/validation.spec.ts
+++ b/packages/core/src/validation.spec.ts
@@ -193,6 +193,51 @@ describe('validation plugin', () => {
       expect(validation.getError(0, 'name')).toBeNull();
     });
 
+    it('treats a rejecting async validator as a failure with the exception message', async () => {
+      const { validation } = setup([
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          asyncValidate: () => Promise.reject(new Error('upstream down')),
+        },
+        { id: 'age', header: 'Age', type: 'number' },
+      ]);
+      const result = await validation.validateCellAsync(0, 'name', 'x');
+      expect(result).toBe('upstream down');
+      expect(validation.getError(0, 'name')?.message).toBe('upstream down');
+    });
+
+    it('kicks off async validation from the sync `validateCell` entry point', async () => {
+      // Wrap the validator so the test can await its full resolution chain.
+      let settled!: Promise<true | string>;
+      const { grid, validation } = setup([
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          asyncValidate: () => {
+            settled = Promise.resolve('async fail' as const);
+            return settled;
+          },
+        },
+        { id: 'age', header: 'Age', type: 'number' },
+      ]);
+      // Listen for the change event triggered when the async result lands.
+      const settledEvent = new Promise<void>((resolve) => {
+        const off = grid.subscribe('validation:change', ({ errors }) => {
+          if (errors.some((e) => e.state === 'invalid')) {
+            off();
+            resolve();
+          }
+        });
+      });
+      // Sync path returns true; async runs in the background.
+      expect(validation.validateCell(0, 'name', 'x')).toBe(true);
+      await settledEvent;
+      expect(validation.getError(0, 'name')?.message).toBe('async fail');
+    });
+
     it('discards stale async results when a newer validation supersedes them', async () => {
       const first = deferred<true | string>();
       const second = deferred<true | string>();
@@ -336,6 +381,29 @@ describe('validation plugin', () => {
       expect(validation.getError(0, 'name')?.message).toBe('Required');
       grid.setCell(0, 'name', 'fixed');
       expect(validation.getError(0, 'name')).toBeNull();
+    });
+
+    it('runs async validators on writes from outside the editing pipeline', async () => {
+      const { grid, validation } = setup([
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          asyncValidate: () => Promise.resolve('async fail' as const),
+        },
+        { id: 'age', header: 'Age', type: 'number' },
+      ]);
+      const settledEvent = new Promise<void>((resolve) => {
+        const off = grid.subscribe('validation:change', ({ errors }) => {
+          if (errors.some((e) => e.state === 'invalid')) {
+            off();
+            resolve();
+          }
+        });
+      });
+      grid.setCell(0, 'name', 'x');
+      await settledEvent;
+      expect(validation.getError(0, 'name')?.message).toBe('async fail');
     });
 
     it('re-validates writes to currently-hidden rows via setCellByDataIndex', () => {

--- a/packages/core/src/validation.spec.ts
+++ b/packages/core/src/validation.spec.ts
@@ -1,0 +1,505 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createEditingPlugin } from './editing';
+import { createGrid } from './grid';
+import type {
+  ColumnDef,
+  EditingPluginApi,
+  Row,
+  ValidationError,
+  ValidationPluginApi,
+} from './types';
+import { createValidationPlugin } from './validation';
+
+const baseColumns: ColumnDef[] = [
+  { id: 'name', header: 'Name', type: 'text' },
+  { id: 'age', header: 'Age', type: 'number' },
+];
+
+const baseData: Row[] = [
+  { name: 'Alice', age: 30 },
+  { name: 'Bob', age: 25 },
+];
+
+interface Setup {
+  grid: ReturnType<typeof createGrid>;
+  editing: EditingPluginApi;
+  validation: ValidationPluginApi;
+}
+
+function setup(columns: ColumnDef[] = baseColumns, data: Row[] = baseData): Setup {
+  const grid = createGrid({
+    data,
+    columns,
+    plugins: [createEditingPlugin(), createValidationPlugin()],
+  });
+  return {
+    grid,
+    editing: grid.getPlugin<EditingPluginApi>('editing')!,
+    validation: grid.getPlugin<ValidationPluginApi>('validation')!,
+  };
+}
+
+// A tiny controllable deferred so tests can resolve async validators at a
+// specific moment — avoids relying on timers or microtask ordering tricks.
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+  reject: (e: unknown) => void;
+} {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('validation plugin', () => {
+  describe('sync validation', () => {
+    it('returns true when the cell is valid', () => {
+      const { validation } = setup([
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          validate: (v) => typeof v === 'string' || 'bad',
+        },
+        { id: 'age', header: 'Age', type: 'number' },
+      ]);
+      expect(validation.validateCell(0, 'name', 'Carol')).toBe(true);
+      expect(validation.getError(0, 'name')).toBeNull();
+    });
+
+    it('returns the error message and records it when invalid', () => {
+      const { validation } = setup([
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          validate: (v) => (typeof v === 'string' && v.length > 0) || 'Required',
+        },
+        { id: 'age', header: 'Age', type: 'number' },
+      ]);
+      expect(validation.validateCell(0, 'name', '')).toBe('Required');
+      const err = validation.getError(0, 'name');
+      expect(err?.message).toBe('Required');
+      expect(err?.state).toBe('invalid');
+      expect(err?.columnId).toBe('name');
+    });
+
+    it('clears a previously recorded error when the cell becomes valid', () => {
+      const { validation } = setup([
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          validate: (v) => (v === 'ok' ? true : 'bad'),
+        },
+        { id: 'age', header: 'Age', type: 'number' },
+      ]);
+      validation.validateCell(0, 'name', 'nope');
+      expect(validation.getError(0, 'name')).not.toBeNull();
+      validation.validateCell(0, 'name', 'ok');
+      expect(validation.getError(0, 'name')).toBeNull();
+    });
+
+    it('treats a thrown validator as a failure with the exception message', () => {
+      const { validation } = setup([
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          validate: () => {
+            throw new Error('boom');
+          },
+        },
+        { id: 'age', header: 'Age', type: 'number' },
+      ]);
+      expect(validation.validateCell(0, 'name', 'x')).toBe('boom');
+      expect(validation.getError(0, 'name')?.message).toBe('boom');
+    });
+
+    it('ignores columns without a validator', () => {
+      const { validation } = setup();
+      expect(validation.validateCell(0, 'name', 'anything')).toBe(true);
+      expect(validation.getError(0, 'name')).toBeNull();
+    });
+  });
+
+  describe('validation:change event', () => {
+    it('fires once when a verdict changes and is quiet on no-op re-validation', () => {
+      const { grid, validation } = setup([
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          validate: (v) => (v === 'ok' ? true : 'bad'),
+        },
+        { id: 'age', header: 'Age', type: 'number' },
+      ]);
+      const spy = vi.fn();
+      grid.subscribe('validation:change', spy);
+
+      validation.validateCell(0, 'name', 'nope'); // fresh error → emits
+      validation.validateCell(0, 'name', 'nope'); // same verdict → no-op
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      validation.validateCell(0, 'name', 'ok'); // clears → emits
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('async validation', () => {
+    it('marks the cell pending then invalid when async resolves with an error', async () => {
+      const d = deferred<true | string>();
+      const { validation } = setup([
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          asyncValidate: () => d.promise,
+        },
+        { id: 'age', header: 'Age', type: 'number' },
+      ]);
+
+      const p = validation.validateCellAsync(0, 'name', 'x');
+      expect(validation.isPending(0, 'name')).toBe(true);
+      d.resolve('Taken');
+      const result = await p;
+      expect(result).toBe('Taken');
+      const err = validation.getError(0, 'name');
+      expect(err?.state).toBe('invalid');
+      expect(err?.message).toBe('Taken');
+    });
+
+    it('clears the pending record when async resolves valid', async () => {
+      const d = deferred<true | string>();
+      const { validation } = setup([
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          asyncValidate: () => d.promise,
+        },
+        { id: 'age', header: 'Age', type: 'number' },
+      ]);
+
+      const p = validation.validateCellAsync(0, 'name', 'x');
+      expect(validation.isPending(0, 'name')).toBe(true);
+      d.resolve(true);
+      await p;
+      expect(validation.getError(0, 'name')).toBeNull();
+    });
+
+    it('discards stale async results when a newer validation supersedes them', async () => {
+      const first = deferred<true | string>();
+      const second = deferred<true | string>();
+      let calls = 0;
+      const { validation } = setup([
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          asyncValidate: () => {
+            calls++;
+            return calls === 1 ? first.promise : second.promise;
+          },
+        },
+        { id: 'age', header: 'Age', type: 'number' },
+      ]);
+
+      const p1 = validation.validateCellAsync(0, 'name', 'a');
+      const p2 = validation.validateCellAsync(0, 'name', 'b');
+      // Resolve the stale one last — the later attempt's verdict must win.
+      second.resolve(true);
+      first.resolve('stale error');
+      await Promise.all([p1, p2]);
+      expect(validation.getError(0, 'name')).toBeNull();
+    });
+  });
+
+  describe('editing integration', () => {
+    it('rejects the commit in reject mode when sync validation fails', () => {
+      const { grid, editing } = setup([
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          validate: (v) => (typeof v === 'string' && v.length > 0) || 'Required',
+        },
+        { id: 'age', header: 'Age', type: 'number' },
+      ]);
+      editing.beginEdit(0, 'name');
+      editing.setValue('');
+      const cancelSpy = vi.fn();
+      grid.subscribe('edit:cancel', cancelSpy);
+      const ok = editing.commitEdit();
+      expect(ok).toBe(false);
+      expect(grid.getCell(0, 'name')).toBe('Alice');
+      expect(cancelSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('commits in warn mode even when the value is invalid', () => {
+      const { grid, editing, validation } = setup([
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          validationMode: 'warn',
+          validate: (v) => (typeof v === 'string' && v.length > 0) || 'Required',
+        },
+        { id: 'age', header: 'Age', type: 'number' },
+      ]);
+      editing.beginEdit(0, 'name');
+      editing.setValue('');
+      const ok = editing.commitEdit();
+      expect(ok).toBe(true);
+      expect(grid.getCell(0, 'name')).toBe('');
+      expect(validation.getError(0, 'name')?.message).toBe('Required');
+    });
+
+    it('clears the error when a subsequent edit fixes the value', () => {
+      const { editing, validation } = setup([
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          validationMode: 'warn',
+          validate: (v) => (typeof v === 'string' && v.length > 0) || 'Required',
+        },
+        { id: 'age', header: 'Age', type: 'number' },
+      ]);
+      editing.beginEdit(0, 'name');
+      editing.setValue('');
+      editing.commitEdit();
+      expect(validation.getError(0, 'name')).not.toBeNull();
+
+      editing.beginEdit(0, 'name');
+      editing.setValue('fine');
+      editing.commitEdit();
+      expect(validation.getError(0, 'name')).toBeNull();
+    });
+  });
+
+  describe('decoration', () => {
+    it('decorates an invalid cell with the error class and data attributes', () => {
+      const { grid, validation } = setup([
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          validate: (v) => (typeof v === 'string' && v.length > 0) || 'Required',
+        },
+        { id: 'age', header: 'Age', type: 'number' },
+      ]);
+      validation.validateCell(0, 'name', '');
+      const decorations = grid.getCellDecorations(0, 'name');
+      expect(decorations).toHaveLength(1);
+      expect(decorations[0].className).toBe('gs-cell--invalid');
+      expect(decorations[0].attributes?.['data-validation-state']).toBe('invalid');
+      expect(decorations[0].attributes?.['data-validation-message']).toBe('Required');
+    });
+
+    it('decorates a pending cell with the validating class', () => {
+      const d = deferred<true | string>();
+      const { grid, validation } = setup([
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          asyncValidate: () => d.promise,
+        },
+        { id: 'age', header: 'Age', type: 'number' },
+      ]);
+      void validation.validateCellAsync(0, 'name', 'x');
+      const decorations = grid.getCellDecorations(0, 'name');
+      expect(decorations).toHaveLength(1);
+      expect(decorations[0].className).toBe('gs-cell--validating');
+      d.resolve(true);
+    });
+  });
+
+  describe('data:change integration', () => {
+    it('re-validates on setCell from outside the editing pipeline', () => {
+      const { grid, validation } = setup([
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          validate: (v) => (typeof v === 'string' && v.length > 0) || 'Required',
+        },
+        { id: 'age', header: 'Age', type: 'number' },
+      ]);
+      grid.setCell(0, 'name', '');
+      expect(validation.getError(0, 'name')?.message).toBe('Required');
+      grid.setCell(0, 'name', 'fixed');
+      expect(validation.getError(0, 'name')).toBeNull();
+    });
+
+    it('re-validates writes to currently-hidden rows via setCellByDataIndex', () => {
+      const { grid, validation } = setup(
+        [
+          {
+            id: 'name',
+            header: 'Name',
+            type: 'text',
+            validate: (v) => (typeof v === 'string' && v.length > 0) || 'Required',
+          },
+          { id: 'age', header: 'Age', type: 'number' },
+        ],
+        [
+          { name: 'Alice', age: 30 },
+          { name: 'Bob', age: 25 },
+        ],
+      );
+      // Filter to "Alice" only — data index 1 (Bob) is hidden.
+      grid.filterState.set([{ columnId: 'name', operator: 'eq', value: 'Alice' }]);
+      grid.setCellByDataIndex(1, 'name', '');
+
+      // Errors are keyed by data-index, so the snapshot reflects the
+      // hidden row's new state even though it isn't in the view.
+      const all = validation.getErrors();
+      expect(all).toHaveLength(1);
+      expect(all[0].dataIndex).toBe(1);
+      expect(all[0].message).toBe('Required');
+    });
+  });
+
+  describe('validateAll', () => {
+    it('returns every failing cell across the data set', async () => {
+      const { validation } = setup(
+        [
+          {
+            id: 'name',
+            header: 'Name',
+            type: 'text',
+            validate: (v) => (typeof v === 'string' && v.length >= 3) || 'Too short',
+          },
+          { id: 'age', header: 'Age', type: 'number' },
+        ],
+        [
+          { name: 'Al', age: 30 },
+          { name: 'Bob', age: 25 },
+          { name: 'Jo', age: 40 },
+        ],
+      );
+      const errors = await validation.validateAll();
+      expect(errors).toHaveLength(2);
+      const ids = errors.map((e: ValidationError) => e.dataIndex).sort();
+      expect(ids).toEqual([0, 2]);
+    });
+
+    it('still validates rows that are filtered out of the view', async () => {
+      const { grid, validation } = setup(
+        [
+          {
+            id: 'name',
+            header: 'Name',
+            type: 'text',
+            validate: (v) => (typeof v === 'string' && v.length >= 3) || 'Too short',
+          },
+          { id: 'age', header: 'Age', type: 'number' },
+        ],
+        [
+          { name: 'Al', age: 30 }, // invalid, filtered out
+          { name: 'Bob', age: 25 }, // valid, visible
+          { name: 'Jo', age: 40 }, // invalid, filtered out
+        ],
+      );
+      // Filter to only "Bob" — leaves data indices 0 and 2 hidden.
+      grid.filterState.set([{ columnId: 'name', operator: 'eq', value: 'Bob' }]);
+      expect(grid.indexMap.get().length).toBe(1);
+
+      const errors = await validation.validateAll();
+      const ids = errors.map((e: ValidationError) => e.dataIndex).sort();
+      // Without the data-index walk, viewToData(2) would throw RangeError
+      // here because the filtered view only has length 1.
+      expect(ids).toEqual([0, 2]);
+    });
+  });
+
+  describe('clearErrors', () => {
+    it('drops recorded errors at various scopes', () => {
+      const { validation } = setup([
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          validate: (v) => (typeof v === 'string' && v.length > 0) || 'Required',
+        },
+        {
+          id: 'age',
+          header: 'Age',
+          type: 'number',
+          validate: (v) => typeof v === 'number' || 'NaN',
+        },
+      ]);
+      validation.validateCell(0, 'name', '');
+      validation.validateCell(1, 'name', '');
+      validation.validateCell(0, 'age', null);
+      expect(validation.getErrors()).toHaveLength(3);
+
+      validation.clearErrors(0, 'name');
+      expect(validation.getErrors()).toHaveLength(2);
+
+      validation.clearErrors(0);
+      expect(validation.getErrors()).toHaveLength(1);
+
+      validation.clearErrors();
+      expect(validation.getErrors()).toHaveLength(0);
+    });
+
+    it('clears every error on a column when only columnId is passed', () => {
+      const { validation } = setup([
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          validate: (v) => (typeof v === 'string' && v.length > 0) || 'Required',
+        },
+        {
+          id: 'age',
+          header: 'Age',
+          type: 'number',
+          validate: (v) => typeof v === 'number' || 'NaN',
+        },
+      ]);
+      validation.validateCell(0, 'name', '');
+      validation.validateCell(1, 'name', '');
+      validation.validateCell(0, 'age', null);
+      expect(validation.getErrors()).toHaveLength(3);
+
+      validation.clearErrors(undefined, 'name');
+      const remaining = validation.getErrors();
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].columnId).toBe('age');
+    });
+  });
+
+  describe('change-event dedupe', () => {
+    it('does not re-emit when the same error is recorded with a fresh Date value', () => {
+      const { grid, validation } = setup([
+        {
+          id: 'joined',
+          header: 'Joined',
+          type: 'date',
+          // Always fails — we want two failing calls with structurally equal
+          // Date values to confirm the dedupe path treats them as equal.
+          validate: () => 'Locked',
+        },
+        { id: 'age', header: 'Age', type: 'number' },
+      ]);
+      const spy = vi.fn();
+      grid.subscribe('validation:change', spy);
+
+      validation.validateCell(0, 'joined', new Date('2026-04-19')); // emits
+      // Second call uses a different Date instance with the same epoch —
+      // `Object.is` would say they're unequal, so without Date-aware equality
+      // the dedupe would miss and a second event would fire.
+      validation.validateCell(0, 'joined', new Date('2026-04-19')); // no-op
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -1,0 +1,415 @@
+import type {
+  AsyncValidator,
+  CellValue,
+  ColumnDef,
+  GridPlugin,
+  Row,
+  SyncValidator,
+  ValidationContext,
+  ValidationError,
+  ValidationPluginApi,
+  ValidationResult,
+} from './types';
+
+// ─── Helpers ───────────────────────────────────────────────
+
+const key = (dataIndex: number, columnId: string): string => `${dataIndex}:${columnId}`;
+
+function findColumn(cols: readonly ColumnDef[], id: string): ColumnDef | undefined {
+  for (const c of cols) if (c.id === id) return c;
+  return undefined;
+}
+
+function cellIsValidatable(col: ColumnDef | undefined): col is ColumnDef {
+  if (!col) return false;
+  return typeof col.validate === 'function' || typeof col.asyncValidate === 'function';
+}
+
+// `Object.is` treats two `Date` instances with the same epoch as unequal — we
+// don't want that, since identical date values shouldn't trigger spurious
+// `validation:change` events.
+function valuesEqual(a: CellValue, b: CellValue): boolean {
+  if (Object.is(a, b)) return true;
+  if (a instanceof Date && b instanceof Date) return a.getTime() === b.getTime();
+  return false;
+}
+
+// ─── Plugin ────────────────────────────────────────────────
+
+export function createValidationPlugin(): GridPlugin {
+  // Key is `${dataIndex}:${columnId}` so errors survive sort/filter and pinned
+  // rows look up with the same shape. `pendingTokens` lets stale async results
+  // be discarded when a newer validation supersedes them.
+  const errors = new Map<string, ValidationError>();
+  const pendingTokens = new Map<string, number>();
+  let tokenCounter = 0;
+
+  const plugin: GridPlugin = {
+    name: 'validation',
+
+    init(ctx) {
+      const grid = ctx.grid;
+
+      const getRow = (dataIndex: number): Row | null => {
+        const snap = grid.data;
+        return snap[dataIndex] ?? null;
+      };
+
+      // Resolve a view-row to a data-row. Returns null if the view index is
+      // out of range — public APIs treat that as a no-op rather than throwing.
+      const safeViewToData = (rowIndex: number): number | null => {
+        const map = grid.indexMap.get();
+        if (rowIndex < 0 || rowIndex >= map.length) return null;
+        return map.viewToData(rowIndex);
+      };
+
+      const buildContext = (
+        rowIndex: number,
+        dataIndex: number,
+        columnId: string,
+        row: Row,
+        originalValue: CellValue,
+      ): ValidationContext => ({ rowIndex, dataIndex, columnId, row, originalValue });
+
+      const emitChange = (): void => {
+        ctx.events.emit('validation:change', { errors: Array.from(errors.values()) });
+      };
+
+      /**
+       * Merge-or-remove a cell's error record. Returns true if anything
+       * changed so callers can skip emitting `validation:change` on no-ops.
+       */
+      const recordError = (error: ValidationError | null, entryKey: string): boolean => {
+        if (!error) {
+          if (!errors.has(entryKey)) return false;
+          errors.delete(entryKey);
+          return true;
+        }
+        const prev = errors.get(entryKey);
+        if (
+          prev &&
+          prev.state === error.state &&
+          prev.message === error.message &&
+          valuesEqual(prev.value, error.value)
+        ) {
+          return false;
+        }
+        errors.set(entryKey, error);
+        return true;
+      };
+
+      const runSyncValidator = (
+        validator: SyncValidator,
+        value: CellValue,
+        vctx: ValidationContext,
+      ): ValidationResult => {
+        try {
+          return validator(value, vctx);
+        } catch (err) {
+          // A thrown validator is treated as a failure rather than a crash —
+          // same user intent as returning a message. The exception message
+          // surfaces so the author can diagnose.
+          return err instanceof Error ? err.message : 'Validator threw';
+        }
+      };
+
+      const kickoffAsync = (
+        validator: AsyncValidator,
+        value: CellValue,
+        vctx: ValidationContext,
+        entryKey: string,
+      ): Promise<ValidationResult> => {
+        const token = ++tokenCounter;
+        pendingTokens.set(entryKey, token);
+
+        // Mark as pending (unless a sync error already sits here — sync error
+        // takes precedence in the UI; pending is only surfaced when no other
+        // verdict is known).
+        if (!errors.has(entryKey)) {
+          errors.set(entryKey, {
+            dataIndex: vctx.dataIndex,
+            columnId: vctx.columnId,
+            message: '',
+            value,
+            state: 'pending',
+          });
+          emitChange();
+        }
+
+        return Promise.resolve()
+          .then(() => validator(value, vctx))
+          .catch(
+            (err): ValidationResult => (err instanceof Error ? err.message : 'Validator threw'),
+          )
+          .then((result) => {
+            // Only apply if we're still the latest attempt; otherwise silently drop.
+            if (pendingTokens.get(entryKey) !== token) return result;
+            pendingTokens.delete(entryKey);
+
+            if (result === true) {
+              // Clear any pending/invalid record owned by this async pass. If
+              // a sync error was recorded separately, leave it alone.
+              const prev = errors.get(entryKey);
+              if (prev && (prev.state === 'pending' || prev.message === '')) {
+                errors.delete(entryKey);
+                emitChange();
+              }
+            } else {
+              const changed = recordError(
+                {
+                  dataIndex: vctx.dataIndex,
+                  columnId: vctx.columnId,
+                  message: result,
+                  value,
+                  state: 'invalid',
+                },
+                entryKey,
+              );
+              if (changed) emitChange();
+            }
+            return result;
+          });
+      };
+
+      // ── Internal core: takes a resolved data-index and column. ──
+      // Both the public view-keyed APIs and the data-keyed internal callers
+      // (validateAll, data:change handler) funnel through these so the
+      // viewToData round-trip happens at most once per call.
+
+      const runSyncCore = (
+        rowIndex: number,
+        dataIndex: number,
+        col: ColumnDef,
+        value: CellValue,
+      ): { result: ValidationResult; vctx: ValidationContext } | null => {
+        const row = getRow(dataIndex);
+        if (!row) return null;
+
+        const entryKey = key(dataIndex, col.id);
+        const vctx = buildContext(rowIndex, dataIndex, col.id, row, row[col.id]);
+
+        let syncResult: ValidationResult = true;
+        if (col.validate) {
+          syncResult = runSyncValidator(col.validate, value, vctx);
+        }
+
+        if (syncResult !== true) {
+          // Abort any in-flight async — its result would race with the
+          // newer sync verdict and has been superseded.
+          pendingTokens.delete(entryKey);
+          const changed = recordError(
+            {
+              dataIndex,
+              columnId: col.id,
+              message: syncResult,
+              value,
+              state: 'invalid',
+            },
+            entryKey,
+          );
+          if (changed) emitChange();
+        } else {
+          // Sync passed: clear any sync-originated error; async pending/error
+          // remains if one is in flight.
+          const prev = errors.get(entryKey);
+          if (prev && prev.state !== 'pending') {
+            const changed = recordError(null, entryKey);
+            if (changed) emitChange();
+          }
+        }
+
+        return { result: syncResult, vctx };
+      };
+
+      const runAsyncCore = async (
+        rowIndex: number,
+        dataIndex: number,
+        col: ColumnDef,
+        value: CellValue,
+      ): Promise<ValidationResult> => {
+        const sync = runSyncCore(rowIndex, dataIndex, col, value);
+        if (!sync) return true;
+        if (sync.result !== true) return sync.result;
+        if (!col.asyncValidate) return true;
+        return kickoffAsync(col.asyncValidate, value, sync.vctx, key(dataIndex, col.id));
+      };
+
+      const api: ValidationPluginApi = {
+        validateCell(rowIndex, columnId, value) {
+          const cols = grid.columns.get();
+          const col = findColumn(cols, columnId);
+          if (!cellIsValidatable(col)) return true;
+
+          const dataIndex = safeViewToData(rowIndex);
+          if (dataIndex === null) return true;
+
+          const row = getRow(dataIndex);
+          if (!row) return true;
+
+          const currentValue = value === undefined ? row[columnId] : value;
+          const sync = runSyncCore(rowIndex, dataIndex, col, currentValue);
+          if (!sync) return true;
+
+          if (col.asyncValidate && sync.result === true) {
+            // Fire-and-forget — caller doesn't await. Swallow promise.
+            void kickoffAsync(col.asyncValidate, currentValue, sync.vctx, key(dataIndex, col.id));
+          }
+          return sync.result;
+        },
+
+        async validateCellAsync(rowIndex, columnId, value) {
+          const cols = grid.columns.get();
+          const col = findColumn(cols, columnId);
+          if (!cellIsValidatable(col)) return true;
+
+          const dataIndex = safeViewToData(rowIndex);
+          if (dataIndex === null) return true;
+
+          const row = getRow(dataIndex);
+          if (!row) return true;
+
+          const currentValue = value === undefined ? row[columnId] : value;
+          return runAsyncCore(rowIndex, dataIndex, col, currentValue);
+        },
+
+        async validateAll() {
+          const cols = grid.columns.get();
+          const snap = grid.data;
+          const indexMap = grid.indexMap.get();
+          const promises: Promise<ValidationResult>[] = [];
+          for (let dataIndex = 0; dataIndex < snap.length; dataIndex++) {
+            const row = snap[dataIndex];
+            if (!row) continue;
+            // Row may be filtered out — pass -1 as the view-row in the ctx so
+            // consumers can detect "not currently visible". Errors are still
+            // keyed by data-index, so they reappear when the filter relaxes.
+            const rowIndex = indexMap.dataToView(dataIndex) ?? -1;
+            for (const col of cols) {
+              if (!cellIsValidatable(col)) continue;
+              promises.push(runAsyncCore(rowIndex, dataIndex, col, row[col.id]));
+            }
+          }
+          await Promise.all(promises);
+          return Array.from(errors.values());
+        },
+
+        getError(rowIndex, columnId) {
+          const dataIndex = safeViewToData(rowIndex);
+          if (dataIndex === null) return null;
+          return errors.get(key(dataIndex, columnId)) ?? null;
+        },
+
+        isPending(rowIndex, columnId) {
+          const err = api.getError(rowIndex, columnId);
+          return err?.state === 'pending';
+        },
+
+        getErrors() {
+          return Array.from(errors.values());
+        },
+
+        clearErrors(rowIndex, columnId) {
+          // No args → clear everything.
+          if (rowIndex === undefined && columnId === undefined) {
+            if (errors.size === 0 && pendingTokens.size === 0) return;
+            errors.clear();
+            pendingTokens.clear();
+            emitChange();
+            return;
+          }
+
+          // Column scope: only `columnId` provided.
+          if (rowIndex === undefined && columnId !== undefined) {
+            const suffix = `:${columnId}`;
+            let changed = false;
+            for (const k of Array.from(errors.keys())) {
+              if (k.endsWith(suffix)) {
+                errors.delete(k);
+                pendingTokens.delete(k);
+                changed = true;
+              }
+            }
+            if (changed) emitChange();
+            return;
+          }
+
+          // Cell or row scope — both need a resolvable view-row.
+          const dataIndex = safeViewToData(rowIndex as number);
+          if (dataIndex === null) return;
+
+          if (columnId !== undefined) {
+            const entryKey = key(dataIndex, columnId);
+            if (!errors.has(entryKey) && !pendingTokens.has(entryKey)) return;
+            errors.delete(entryKey);
+            pendingTokens.delete(entryKey);
+            emitChange();
+            return;
+          }
+
+          // Row-scope clear: strip every key that starts with `${dataIndex}:`.
+          const prefix = `${dataIndex}:`;
+          let changed = false;
+          for (const k of Array.from(errors.keys())) {
+            if (k.startsWith(prefix)) {
+              errors.delete(k);
+              pendingTokens.delete(k);
+              changed = true;
+            }
+          }
+          if (changed) emitChange();
+        },
+      };
+
+      ctx.expose('validation', api);
+
+      // Cell decoration: invalid → red border + tooltip text via data-attr so a
+      // React (or any) adapter can render a native title or custom tooltip.
+      ctx.addCellDecorator(({ row, col }) => {
+        const di = safeViewToData(row);
+        if (di === null) return null;
+        const err = errors.get(key(di, col));
+        if (!err) return null;
+        const attributes: Record<string, string> = { 'data-validation-state': err.state };
+        if (err.state === 'pending') {
+          return { className: 'gs-cell--validating', attributes };
+        }
+        attributes['data-validation-message'] = err.message;
+        // Native `title` is the fallback tooltip — the React adapter renders a
+        // styled overlay on top of it, but consumers without the overlay still
+        // see the error message on hover with zero extra code.
+        attributes.title = err.message;
+        return { className: 'gs-cell--invalid', attributes };
+      });
+
+      // When a cell's value changes outside the editing pipeline (clipboard
+      // paste, fill handle, programmatic `setCell`/`setCellByDataIndex`),
+      // re-run validation so decoration stays accurate. Validates by data
+      // index so writes to currently-hidden rows are still re-checked.
+      const unsubData = ctx.events.on('data:change', ({ changes }) => {
+        const cols = grid.columns.get();
+        const indexMap = grid.indexMap.get();
+        for (const change of changes) {
+          const col = findColumn(cols, change.col);
+          if (!cellIsValidatable(col)) continue;
+          const dataIndex = change.row;
+          const row = getRow(dataIndex);
+          if (!row) continue;
+          const rowIndex = indexMap.dataToView(dataIndex) ?? -1;
+          runSyncCore(rowIndex, dataIndex, col, change.newValue);
+          if (col.asyncValidate) {
+            const vctx = buildContext(rowIndex, dataIndex, col.id, row, row[col.id]);
+            void kickoffAsync(col.asyncValidate, change.newValue, vctx, key(dataIndex, col.id));
+          }
+        }
+      });
+
+      return () => {
+        unsubData();
+        errors.clear();
+        pendingTokens.clear();
+      };
+    },
+  };
+
+  return plugin;
+}

--- a/packages/react/src/grid.tsx
+++ b/packages/react/src/grid.tsx
@@ -21,6 +21,7 @@ import {
   createFillHandlePlugin,
   createHistoryPlugin,
   createSelectionPlugin,
+  createValidationPlugin,
   flattenColumns,
   getHeaderDepth,
   getTotalHeight,
@@ -127,12 +128,14 @@ export const Grid = memo(function Grid({
     const clipboardPlugin = createClipboardPlugin();
     const historyPlugin = createHistoryPlugin();
     const fillHandlePlugin = createFillHandlePlugin();
+    const validationPlugin = createValidationPlugin();
     const builtins = [
       editingPlugin,
       selectionPlugin,
       clipboardPlugin,
       historyPlugin,
       fillHandlePlugin,
+      validationPlugin,
     ];
     return plugins ? [...builtins, ...plugins] : builtins;
   });
@@ -268,12 +271,16 @@ export const Grid = memo(function Grid({
   const indexMap = useSignalValue(grid.indexMap);
   const totalRows = indexMap.length;
 
-  // Data version counter — triggers row re-render on cell/data changes
+  // Data version counter — triggers row re-render on cell/data changes.
+  // Validation state changes that leave the underlying cell value untouched
+  // (pending → invalid, async settle) also bump the counter so invalid-cell
+  // decoration and tooltips stay in sync with the plugin's state.
   const [dataVersion, setDataVersion] = useState(0);
   useEffect(() => {
     const unsubs = [
       grid.subscribe('data:change', () => setDataVersion((v) => v + 1)),
       grid.subscribe('data:rowsUpdate', () => setDataVersion((v) => v + 1)),
+      grid.subscribe('validation:change', () => setDataVersion((v) => v + 1)),
     ];
     return () => unsubs.forEach((u) => u());
   }, [grid]);

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -9,6 +9,7 @@ export { useGridSelection } from './use-grid-selection';
 export type { SelectionState } from './use-grid-selection';
 export { useGridClipboard } from './use-grid-clipboard';
 export { useGridFillHandle } from './use-grid-fill-handle';
+export { useGridValidation } from './use-grid-validation';
 
 // Types
 export type { GridProps, GridColumnDef, CellRendererProps, CellEditorProps } from './types';
@@ -49,10 +50,19 @@ export {
   type FillOperation,
   type FillHandlePluginOptions,
   type FillHandlePluginApi,
+  type ValidationResult,
+  type ValidationContext,
+  type ValidationMode,
+  type ValidationErrorState,
+  type ValidationError,
+  type ValidationPluginApi,
+  type SyncValidator,
+  type AsyncValidator,
   createClipboardPlugin,
   createEditingPlugin,
   createFillHandlePlugin,
   createHistoryPlugin,
+  createValidationPlugin,
   flattenColumns,
   getHeaderDepth,
   buildHeaderRows,

--- a/packages/react/src/use-grid-validation.ts
+++ b/packages/react/src/use-grid-validation.ts
@@ -1,0 +1,10 @@
+import type { GridInstance, ValidationPluginApi } from '@gridsmith/core';
+import { useMemo } from 'react';
+
+/**
+ * Read the validation plugin API off a grid instance. Returns the same
+ * reference across renders for stable callback identities.
+ */
+export function useGridValidation(grid: GridInstance): ValidationPluginApi | null {
+  return useMemo(() => grid.getPlugin<ValidationPluginApi>('validation') ?? null, [grid]);
+}

--- a/packages/react/src/validation.spec.tsx
+++ b/packages/react/src/validation.spec.tsx
@@ -1,0 +1,117 @@
+import { act, fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Grid } from './grid';
+import type { GridColumnDef } from './types';
+
+// ─── DOM mocks (copied from editing.spec.tsx shape) ───────
+
+const origCW = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+const origCH = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+
+beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    get() {
+      return 500;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    get() {
+      return 300;
+    },
+  });
+
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+afterEach(() => {
+  if (origCW) Object.defineProperty(HTMLElement.prototype, 'clientWidth', origCW);
+  if (origCH) Object.defineProperty(HTMLElement.prototype, 'clientHeight', origCH);
+  vi.restoreAllMocks();
+});
+
+// ─── Fixtures ─────────────────────────────────────────────
+
+const columns: GridColumnDef[] = [
+  {
+    id: 'name',
+    header: 'Name',
+    type: 'text',
+    validate: (v) => (typeof v === 'string' && v.length > 0) || 'Required',
+  },
+  { id: 'age', header: 'Age', type: 'number' },
+];
+
+const data = [
+  { name: 'Alice', age: 30 },
+  { name: 'Bob', age: 25 },
+];
+
+function findCell(row: number, col: string): HTMLElement | null {
+  return document.querySelector(`[data-row="${row}"][data-col="${col}"]`);
+}
+
+describe('Grid validation integration', () => {
+  it('auto-registers the validation plugin', () => {
+    render(<Grid data={data} columns={columns} />);
+    // A grid where the user hasn't edited anything shouldn't decorate cells
+    // as invalid — validation only runs on explicit trigger (commit, setCell).
+    const cell = findCell(0, 'name')!;
+    expect(cell.classList.contains('gs-cell--invalid')).toBe(false);
+  });
+
+  it('decorates an invalid cell after a warn-mode commit', () => {
+    const warnColumns: GridColumnDef[] = [
+      {
+        id: 'name',
+        header: 'Name',
+        type: 'text',
+        validationMode: 'warn',
+        validate: (v) => (typeof v === 'string' && v.length > 0) || 'Required',
+      },
+      { id: 'age', header: 'Age', type: 'number' },
+    ];
+    render(<Grid data={data} columns={warnColumns} />);
+
+    const cell = findCell(0, 'name')!;
+    // Double-click opens editor
+    fireEvent.doubleClick(cell);
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    // Clear and commit empty value (invalid)
+    fireEvent.change(input, { target: { value: '' } });
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+    });
+
+    const updated = findCell(0, 'name')!;
+    expect(updated.classList.contains('gs-cell--invalid')).toBe(true);
+    expect(updated.getAttribute('title')).toBe('Required');
+    expect(updated.getAttribute('data-validation-message')).toBe('Required');
+  });
+
+  it('rejects a reject-mode commit and keeps the original value', () => {
+    render(<Grid data={data} columns={columns} />);
+    const cell = findCell(0, 'name')!;
+    fireEvent.doubleClick(cell);
+    const input = document.querySelector('.gs-cell-editor input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '' } });
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+    });
+
+    const after = findCell(0, 'name')!;
+    expect(after.textContent).toBe('Alice');
+    // Reject-mode rollback never records an error — the value was refused outright.
+    expect(after.classList.contains('gs-cell--invalid')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- New `createValidationPlugin` records per-cell errors keyed by stable data-index, so validation state survives sort, filter, reorder, and pinned rows. Columns declare `validate` (sync) and/or `asyncValidate`; validators return `true` or an error message.
- `validationMode: 'reject' | 'warn'` (default `reject`) controls commit behavior. The editing plugin calls `validateCell` before `setCell`, so a rejected commit never touches grid data; the cell keeps its pre-edit value (and stays decorated only if that value is itself invalid).
- Async validators flag the cell `pending` and use token-based cancellation to discard stale results when newer runs supersede them. `validateAll` walks by data-index — including filtered-out rows — and the `data:change` listener does the same, so programmatic writes (clipboard paste, fill handle, `setCellByDataIndex`) keep the error map in sync even for hidden rows.
- React adapter auto-registers the plugin and exposes `useGridValidation(grid)`. Cell decorator emits `gs-cell--invalid` / `gs-cell--validating` with `title` + `data-validation-message` for tooltips.

Closes #14.

## Test plan

- [x] 23 new core tests (sync, async, change-event dedupe, decoration, data:change, validateAll across filter, clearErrors at all 4 scopes)
- [x] 3 new React integration tests (auto-registration, warn-mode decoration, reject-mode rollback)
- [x] Coverage: validation.ts branch 75%, lifts global past the 80% threshold
- [x] Manual: playground exercises both modes — Name (reject) and Age (warn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)