### PR TITLE
feat: change tracking — dirty cells, batch commit/revert (#16)

### DIFF
--- a/.changeset/change-tracking.md
+++ b/.changeset/change-tracking.md
@@ -1,0 +1,33 @@
+---
+'@gridsmith/core': minor
+---
+
+Add change tracking with dirty-cell marking, batch commit, and batch revert.
+
+**Core (`@gridsmith/core`):**
+
+- New `createChangesPlugin()` exports a `'changes'` plugin that tracks
+  every cell edit since the last commit/revert. Entries are keyed by
+  stable data index, so dirty state survives sort, filter, and pinned-
+  row reindexing.
+- `ChangesPluginApi`:
+  - `getDirty(): CellChange[]` — snapshot of every dirty cell with its
+    original and current values.
+  - `isDirty(rowIndex, columnId): boolean` — view-indexed lookup.
+  - `commit()` — accept the current values as the new baseline; clears
+    the dirty set without touching cell values or undo history.
+  - `revert()` — restore every dirty cell to its original value in a
+    single `grid.batchUpdate` (one undoable step when history is
+    present).
+- Cells in the dirty set pick up a `gs-cell--dirty` CSS class via the
+  cell-decorator hook so adapters can render an indicator (e.g. a
+  blue corner triangle).
+- New events on `GridEvents`: `'changes:update'` (fires on any dirty-
+  state mutation), `'changes:commit'`, and `'changes:revert'`, each
+  carrying the relevant `CellChange[]` snapshot.
+- A cell edited back to its original value — including `Date`
+  instances with the same epoch — is automatically evicted from the
+  dirty set.
+- Wholesale `setData` and column-set changes (removing a column via
+  `setColumns`) invalidate the affected entries; pure column
+  reorders do not.

--- a/apps/playground/index.html
+++ b/apps/playground/index.html
@@ -12,6 +12,18 @@
       .gs-cell--validating {
         box-shadow: inset 0 0 0 2px #f59e0b;
       }
+      .gs-cell--dirty {
+        position: relative;
+      }
+      .gs-cell--dirty::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        right: 0;
+        border-style: solid;
+        border-width: 6px 6px 0 0;
+        border-color: #2563eb transparent transparent transparent;
+      }
       .gs-cell--loading {
         background: linear-gradient(90deg, #f1f5f9 0%, #e2e8f0 50%, #f1f5f9 100%);
         background-size: 200% 100%;

--- a/packages/core/src/changes.spec.ts
+++ b/packages/core/src/changes.spec.ts
@@ -1,0 +1,320 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+
+import { createChangesPlugin } from './changes';
+import { createGrid } from './grid';
+import { createHistoryPlugin } from './history';
+import type { ChangesPluginApi, ColumnDef, HistoryPluginApi, Row } from './types';
+
+const baseColumns: ColumnDef[] = [
+  { id: 'a', header: 'A', type: 'text' },
+  { id: 'b', header: 'B', type: 'number' },
+  { id: 'c', header: 'C', type: 'text' },
+];
+
+const baseData: Row[] = [
+  { a: 'a0', b: 10, c: 'c0' },
+  { a: 'a1', b: 20, c: 'c1' },
+  { a: 'a2', b: 30, c: 'c2' },
+];
+
+function setup(opts: { withHistory?: boolean; data?: Row[]; columns?: ColumnDef[] } = {}) {
+  const plugins = [createChangesPlugin()];
+  if (opts.withHistory) plugins.push(createHistoryPlugin());
+  const grid = createGrid({
+    data: opts.data ?? baseData.map((r) => ({ ...r })),
+    columns: opts.columns ?? baseColumns,
+    plugins,
+  });
+  return {
+    grid,
+    changes: grid.getPlugin<ChangesPluginApi>('changes')!,
+    history: grid.getPlugin<HistoryPluginApi>('history'),
+  };
+}
+
+describe('changes plugin', () => {
+  describe('tracking', () => {
+    it('marks a cell dirty on setCell and records original value', () => {
+      const { grid, changes } = setup();
+
+      grid.setCell(0, 'a', 'edited');
+
+      expect(changes.isDirty(0, 'a')).toBe(true);
+      expect(changes.getDirty()).toEqual([
+        { row: 0, col: 'a', oldValue: 'a0', newValue: 'edited' },
+      ]);
+    });
+
+    it('tracks multiple cells independently', () => {
+      const { grid, changes } = setup();
+
+      grid.setCell(0, 'a', 'x');
+      grid.setCell(1, 'b', 99);
+
+      expect(changes.getDirty()).toHaveLength(2);
+      expect(changes.isDirty(0, 'a')).toBe(true);
+      expect(changes.isDirty(1, 'b')).toBe(true);
+      expect(changes.isDirty(0, 'b')).toBe(false);
+    });
+
+    it('preserves the original value when a cell is edited multiple times', () => {
+      const { grid, changes } = setup();
+
+      grid.setCell(0, 'a', 'first');
+      grid.setCell(0, 'a', 'second');
+      grid.setCell(0, 'a', 'third');
+
+      expect(changes.getDirty()).toEqual([{ row: 0, col: 'a', oldValue: 'a0', newValue: 'third' }]);
+    });
+
+    it('drops an entry when the cell is edited back to its original value', () => {
+      const { grid, changes } = setup();
+
+      grid.setCell(0, 'a', 'edited');
+      expect(changes.isDirty(0, 'a')).toBe(true);
+
+      grid.setCell(0, 'a', 'a0');
+      expect(changes.isDirty(0, 'a')).toBe(false);
+      expect(changes.getDirty()).toEqual([]);
+    });
+
+    it('treats Date values with the same epoch as equal when restoring', () => {
+      const columns: ColumnDef[] = [{ id: 'd', header: 'D', type: 'date' }];
+      const originalDate = new Date(2024, 0, 1);
+      const { grid, changes } = setup({ data: [{ d: originalDate }], columns });
+
+      grid.setCell(0, 'd', new Date(2024, 5, 1));
+      expect(changes.isDirty(0, 'd')).toBe(true);
+
+      // Semantically equal Date — different instance. Should drop the entry.
+      grid.setCell(0, 'd', new Date(2024, 0, 1));
+      expect(changes.isDirty(0, 'd')).toBe(false);
+    });
+
+    it('isDirty returns false for out-of-range view rows', () => {
+      const { changes } = setup();
+      expect(changes.isDirty(-1, 'a')).toBe(false);
+      expect(changes.isDirty(999, 'a')).toBe(false);
+    });
+
+    it('getDirty returns entries by data-index so they survive filtering', () => {
+      const { grid, changes } = setup();
+
+      grid.setCell(2, 'a', 'edited');
+      grid.filterState.set([{ columnId: 'a', operator: 'eq', value: 'a0' }]);
+
+      // View row 2 is filtered out — isDirty can't resolve it.
+      expect(changes.isDirty(2, 'a')).toBe(false);
+      // But the record is still there, keyed by data-index.
+      expect(changes.getDirty()).toEqual([
+        { row: 2, col: 'a', oldValue: 'a2', newValue: 'edited' },
+      ]);
+    });
+  });
+
+  describe('commit', () => {
+    it('clears dirty state', () => {
+      const { grid, changes } = setup();
+
+      grid.setCell(0, 'a', 'x');
+      grid.setCell(1, 'b', 99);
+
+      changes.commit();
+
+      expect(changes.getDirty()).toEqual([]);
+      expect(changes.isDirty(0, 'a')).toBe(false);
+    });
+
+    it('does not touch cell values', () => {
+      const { grid, changes } = setup();
+
+      grid.setCell(0, 'a', 'x');
+      changes.commit();
+
+      expect(grid.getCell(0, 'a')).toBe('x');
+    });
+
+    it('after commit, a new edit is tracked against the committed value', () => {
+      const { grid, changes } = setup();
+
+      grid.setCell(0, 'a', 'first');
+      changes.commit();
+
+      grid.setCell(0, 'a', 'second');
+      expect(changes.getDirty()).toEqual([
+        { row: 0, col: 'a', oldValue: 'first', newValue: 'second' },
+      ]);
+    });
+
+    it('emits changes:commit with the committed snapshot and changes:update with empty dirty', () => {
+      const { grid, changes } = setup();
+      grid.setCell(0, 'a', 'x');
+
+      const commitHandler = vi.fn();
+      const updateHandler = vi.fn();
+      grid.subscribe('changes:commit', commitHandler);
+      grid.subscribe('changes:update', updateHandler);
+
+      changes.commit();
+
+      expect(commitHandler).toHaveBeenCalledWith({
+        changes: [{ row: 0, col: 'a', oldValue: 'a0', newValue: 'x' }],
+      });
+      expect(updateHandler).toHaveBeenCalledWith({ dirty: [] });
+    });
+
+    it('emits an empty commit event when nothing is dirty', () => {
+      const { grid, changes } = setup();
+      const handler = vi.fn();
+      grid.subscribe('changes:commit', handler);
+
+      changes.commit();
+      expect(handler).toHaveBeenCalledWith({ changes: [] });
+    });
+  });
+
+  describe('revert', () => {
+    it('restores original values for all dirty cells', () => {
+      const { grid, changes } = setup();
+
+      grid.setCell(0, 'a', 'x');
+      grid.setCell(1, 'b', 99);
+
+      changes.revert();
+
+      expect(grid.getCell(0, 'a')).toBe('a0');
+      expect(grid.getCell(1, 'b')).toBe(20);
+      expect(changes.getDirty()).toEqual([]);
+    });
+
+    it('emits changes:revert with the pre-revert snapshot', () => {
+      const { grid, changes } = setup();
+      grid.setCell(0, 'a', 'x');
+
+      const handler = vi.fn();
+      grid.subscribe('changes:revert', handler);
+
+      changes.revert();
+
+      expect(handler).toHaveBeenCalledWith({
+        changes: [{ row: 0, col: 'a', oldValue: 'a0', newValue: 'x' }],
+      });
+    });
+
+    it('works on cells that are filtered out of the current view', () => {
+      const { grid, changes } = setup();
+
+      grid.setCell(2, 'a', 'edited');
+      grid.filterState.set([{ columnId: 'a', operator: 'eq', value: 'a0' }]);
+
+      changes.revert();
+
+      grid.filterState.set([]);
+      expect(grid.getCell(2, 'a')).toBe('a2');
+      expect(changes.getDirty()).toEqual([]);
+    });
+
+    it('is undoable as a single step when history is present', () => {
+      const { grid, changes, history } = setup({ withHistory: true });
+
+      grid.setCell(0, 'a', 'x');
+      grid.setCell(1, 'b', 99);
+      const undoBefore = history!.getUndoSize();
+
+      changes.revert();
+      expect(grid.getCell(0, 'a')).toBe('a0');
+      expect(grid.getCell(1, 'b')).toBe(20);
+
+      // One additional undoable entry for the batched revert.
+      expect(history!.getUndoSize()).toBe(undoBefore + 1);
+      history!.undo();
+      expect(grid.getCell(0, 'a')).toBe('x');
+      expect(grid.getCell(1, 'b')).toBe(99);
+    });
+
+    it('emits an empty revert event when nothing is dirty', () => {
+      const { grid, changes } = setup();
+      const handler = vi.fn();
+      grid.subscribe('changes:revert', handler);
+
+      changes.revert();
+      expect(handler).toHaveBeenCalledWith({ changes: [] });
+    });
+  });
+
+  describe('events', () => {
+    it('emits changes:update on every dirty-state mutation', () => {
+      const { grid, changes } = setup();
+      const handler = vi.fn();
+      grid.subscribe('changes:update', handler);
+
+      grid.setCell(0, 'a', 'x');
+      grid.setCell(0, 'a', 'y');
+      grid.setCell(0, 'a', 'a0'); // reverts to original → dropped
+
+      expect(handler).toHaveBeenCalledTimes(3);
+      expect(handler.mock.calls[0][0]).toEqual({
+        dirty: [{ row: 0, col: 'a', oldValue: 'a0', newValue: 'x' }],
+      });
+      expect(handler.mock.calls[2][0]).toEqual({ dirty: [] });
+      expect(changes.getDirty()).toEqual([]);
+    });
+
+    it('does not emit when a setCell is a no-op', () => {
+      const { grid } = setup();
+      const handler = vi.fn();
+      grid.subscribe('changes:update', handler);
+
+      grid.setCell(0, 'a', 'a0');
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('decorator', () => {
+    it('surfaces gs-cell--dirty on dirty cells only', () => {
+      const { grid } = setup();
+
+      grid.setCell(0, 'a', 'x');
+
+      const dirty = grid.getCellDecorations(0, 'a');
+      const clean = grid.getCellDecorations(0, 'b');
+      expect(dirty.some((d) => d.className === 'gs-cell--dirty')).toBe(true);
+      expect(clean.some((d) => d.className === 'gs-cell--dirty')).toBe(false);
+    });
+  });
+
+  describe('schema invalidation', () => {
+    it('clears dirty state when setData replaces rows wholesale', () => {
+      const { grid, changes } = setup();
+      grid.setCell(0, 'a', 'x');
+      expect(changes.getDirty()).toHaveLength(1);
+
+      grid.setData([{ a: 'fresh', b: 1, c: 'c' }]);
+      expect(changes.getDirty()).toEqual([]);
+    });
+
+    it('drops entries for columns removed via setColumns', () => {
+      const { grid, changes } = setup();
+      grid.setCell(0, 'a', 'x');
+      grid.setCell(0, 'b', 99);
+
+      grid.setColumns([
+        { id: 'a', header: 'A', type: 'text' },
+        { id: 'c', header: 'C', type: 'text' },
+      ]);
+
+      const remaining = changes.getDirty();
+      expect(remaining).toEqual([{ row: 0, col: 'a', oldValue: 'a0', newValue: 'x' }]);
+    });
+
+    it('keeps entries intact across a pure column reorder', () => {
+      const { grid, changes } = setup();
+      grid.setCell(0, 'a', 'x');
+
+      grid.reorderColumn(0, 2);
+
+      expect(changes.getDirty()).toEqual([{ row: 0, col: 'a', oldValue: 'a0', newValue: 'x' }]);
+    });
+  });
+});

--- a/packages/core/src/changes.ts
+++ b/packages/core/src/changes.ts
@@ -1,0 +1,196 @@
+import type { CellChange, CellValue, ChangesPluginApi, ColumnDef, GridPlugin } from './types';
+
+const key = (dataIndex: number, columnId: string): string => `${dataIndex}:${columnId}`;
+
+// `Object.is` treats two `Date` instances with the same epoch as unequal,
+// which would leave a cell "dirty" even after the user restored a semantically
+// identical date. Matches the rule validation.ts uses for the same reason.
+function valuesEqual(a: CellValue, b: CellValue): boolean {
+  if (Object.is(a, b)) return true;
+  if (a instanceof Date && b instanceof Date) return a.getTime() === b.getTime();
+  return false;
+}
+
+interface DirtyEntry {
+  dataIndex: number;
+  columnId: string;
+  originalValue: CellValue;
+  currentValue: CellValue;
+}
+
+function toCellChange(entry: DirtyEntry): CellChange {
+  return {
+    row: entry.dataIndex,
+    col: entry.columnId,
+    oldValue: entry.originalValue,
+    newValue: entry.currentValue,
+  };
+}
+
+export function createChangesPlugin(): GridPlugin {
+  // Keyed by `${dataIndex}:${columnId}` so entries are stable across sort/filter
+  // and round-trip the same way validation's error map does.
+  const dirty = new Map<string, DirtyEntry>();
+
+  const plugin: GridPlugin = {
+    name: 'changes',
+
+    init(ctx) {
+      const grid = ctx.grid;
+
+      const snapshot = (): CellChange[] => {
+        const out: CellChange[] = [];
+        for (const entry of dirty.values()) out.push(toCellChange(entry));
+        return out;
+      };
+
+      const emitUpdate = (): void => {
+        ctx.events.emit('changes:update', { dirty: snapshot() });
+      };
+
+      const unsubData = ctx.events.on('data:change', ({ changes }) => {
+        let changed = false;
+        for (const change of changes) {
+          const entryKey = key(change.row, change.col);
+          const existing = dirty.get(entryKey);
+          if (existing) {
+            // Preserve the very first `oldValue`; only the latest write wins
+            // on the new side. If that lands us back at the original, the
+            // cell is no longer dirty — drop the entry so the indicator and
+            // `getDirty()` stay accurate.
+            if (valuesEqual(existing.originalValue, change.newValue)) {
+              dirty.delete(entryKey);
+              changed = true;
+            } else if (!valuesEqual(existing.currentValue, change.newValue)) {
+              existing.currentValue = change.newValue;
+              changed = true;
+            }
+          } else {
+            // First write at this cell since the last commit/revert. The
+            // event's `oldValue` is our baseline.
+            if (valuesEqual(change.oldValue, change.newValue)) continue;
+            dirty.set(entryKey, {
+              dataIndex: change.row,
+              columnId: change.col,
+              originalValue: change.oldValue,
+              currentValue: change.newValue,
+            });
+            changed = true;
+          }
+        }
+        if (changed) emitUpdate();
+      });
+
+      // A wholesale `setData` invalidates every stored data-index. Drop the
+      // dirty set — the new rows have no relationship to the recorded edits.
+      const unsubRows = ctx.events.on('data:rowsUpdate', () => {
+        if (dirty.size === 0) return;
+        dirty.clear();
+        emitUpdate();
+      });
+
+      // If a column disappears from the leaf set, its dirty entries are stale
+      // (the field no longer exists on the row). Mirror history's approach:
+      // only react when the *set* of ids changed, not pure reorders.
+      let lastColumnIds = columnIdSet(grid.columns.peek());
+      const unsubCols = ctx.events.on('columns:update', ({ columns }) => {
+        const nextIds = columnIdSet(columns);
+        if (nextIds === lastColumnIds) return;
+        lastColumnIds = nextIds;
+        const live = new Set(columns.map((c: ColumnDef) => c.id));
+        let changed = false;
+        for (const [k, entry] of Array.from(dirty.entries())) {
+          if (!live.has(entry.columnId)) {
+            dirty.delete(k);
+            changed = true;
+          }
+        }
+        if (changed) emitUpdate();
+      });
+
+      const safeViewToData = (rowIndex: number): number | null => {
+        const map = grid.indexMap.get();
+        if (rowIndex < 0 || rowIndex >= map.length) return null;
+        return map.viewToData(rowIndex);
+      };
+
+      const api: ChangesPluginApi = {
+        getDirty() {
+          return snapshot();
+        },
+
+        isDirty(rowIndex, columnId) {
+          const dataIndex = safeViewToData(rowIndex);
+          if (dataIndex === null) return false;
+          return dirty.has(key(dataIndex, columnId));
+        },
+
+        commit() {
+          if (dirty.size === 0) {
+            ctx.events.emit('changes:commit', { changes: [] });
+            return;
+          }
+          const committed = snapshot();
+          dirty.clear();
+          ctx.events.emit('changes:commit', { changes: committed });
+          emitUpdate();
+        },
+
+        revert() {
+          if (dirty.size === 0) {
+            ctx.events.emit('changes:revert', { changes: [] });
+            return;
+          }
+          // Snapshot first: the writes below will fire `data:change`, which
+          // mutates the dirty map in-flight (cells with `newValue ===
+          // originalValue` self-evict). The snapshot captures what we
+          // intended to revert for the emitted event payload.
+          const reverted = snapshot();
+          grid.batchUpdate(() => {
+            for (const change of reverted) {
+              grid.setCellByDataIndex(change.row, change.col, change.oldValue);
+            }
+          });
+          // The `data:change` handler should have cleared the matching entries
+          // as each write landed. Anything lingering is a write whose oldValue
+          // was rejected (e.g. a column pinned to a computed value); clear it
+          // so the API stays internally consistent.
+          if (dirty.size > 0) {
+            dirty.clear();
+            emitUpdate();
+          }
+          ctx.events.emit('changes:revert', { changes: reverted });
+        },
+      };
+
+      ctx.expose('changes', api);
+
+      // Cells in the dirty set pick up `gs-cell--dirty` so the default stylesheet
+      // (or any consumer CSS) can render the corner indicator.
+      ctx.addCellDecorator(({ row, col }) => {
+        const dataIndex = safeViewToData(row);
+        if (dataIndex === null) return null;
+        if (!dirty.has(key(dataIndex, col))) return null;
+        return { className: 'gs-cell--dirty' };
+      });
+
+      return () => {
+        unsubData();
+        unsubRows();
+        unsubCols();
+        dirty.clear();
+      };
+    },
+  };
+
+  return plugin;
+}
+
+function columnIdSet(cols: readonly { id: string }[]): string {
+  return cols
+    .map((c) => c.id)
+    .sort()
+    .join('\u0000');
+}
+
+export type { ChangesPluginApi };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,9 @@ export { createValidationPlugin } from './validation';
 // Async data source
 export { createAsyncDataPlugin } from './async-data';
 
+// Change tracking
+export { createChangesPlugin } from './changes';
+
 // Column grouping
 export {
   flattenColumns,
@@ -102,6 +105,7 @@ export type {
   ValidationPluginApi,
   SyncValidator,
   AsyncValidator,
+  ChangesPluginApi,
   AsyncDataSource,
   AsyncDataSourceParams,
   AsyncDataSourceCountParams,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -181,6 +181,9 @@ export interface GridEvents {
   'transaction:end': { depth: number };
   'history:change': { canUndo: boolean; canRedo: boolean; undoSize: number; redoSize: number };
   'validation:change': { errors: readonly ValidationError[] };
+  'changes:update': { dirty: readonly CellChange[] };
+  'changes:commit': { changes: readonly CellChange[] };
+  'changes:revert': { changes: readonly CellChange[] };
   'asyncData:ready': { totalCount: number };
   'asyncData:loading': { start: number; end: number };
   'asyncData:loaded': { start: number; end: number; totalCount: number };
@@ -522,6 +525,48 @@ export interface ValidationPluginApi {
    * - `(rowIndex, columnId)` — clear a single cell.
    */
   clearErrors(rowIndex?: number, columnId?: string): void;
+}
+
+// ─── Change Tracking ──────────────────────────────────────
+
+/**
+ * Tracks which cells have been edited since the last `commit()`/`revert()`
+ * (or since the plugin was initialized). Each dirty entry records the value
+ * the cell held when it first became dirty (`oldValue`) and the latest value
+ * written to it (`newValue`); `row` is a stable data-index so the record
+ * survives sort/filter and pinned-row reindexing.
+ *
+ * A cell that is edited back to its original value ceases to be dirty and
+ * drops out of the map (same equality rules as `writeCellByDataIndex`, with
+ * `Date`-epoch equality on top so identical dates don't linger).
+ */
+export interface ChangesPluginApi {
+  /**
+   * Every currently dirty cell. `CellChange.row` here is a **data-index** —
+   * stable across sort, filter, and pinned-row reindexing — not the view-row
+   * that `isDirty` takes. Use `grid.indexMap.get().dataToView(change.row)` to
+   * locate a dirty cell in the current view, or `null` when it's filtered out.
+   */
+  getDirty(): CellChange[];
+  /**
+   * `true` when the cell is currently dirty. `rowIndex` is a **view-row**; a
+   * filtered-out data-row cannot be queried through this API (returns `false`).
+   * Use `getDirty()` to enumerate dirty cells outside the current view.
+   */
+  isDirty(rowIndex: number, columnId: string): boolean;
+  /**
+   * Accept every outstanding edit as the new baseline: clears the dirty set
+   * and emits `changes:commit` with the committed snapshot followed by
+   * `changes:update` with the now-empty dirty list. Does not touch the grid's
+   * cell values or undo history.
+   */
+  commit(): void;
+  /**
+   * Restore every dirty cell to its `oldValue`. The writes are wrapped in a
+   * single `grid.batchUpdate` so they appear as one undoable step. Emits
+   * `changes:revert` with the pre-revert snapshot once the writes settle.
+   */
+  revert(): void;
 }
 
 // ─── Async Data Source ────────────────────────────────────


### PR DESCRIPTION
## Summary

- New `createChangesPlugin()` on `@gridsmith/core` exposing `grid.changes.getDirty() / isDirty() / commit() / revert()`, keyed by stable data-index so dirty state survives sort, filter, and pinned-row reindexing.
- Cells edited back to their original value (including `Date` instances with the same epoch) self-evict from the dirty set; `revert()` wraps writes in `grid.batchUpdate` so it reads as a single undoable step when the history plugin is installed.
- Adds `gs-cell--dirty` cell-decorator class; playground ships a blue-corner-triangle default. New events: `changes:update`, `changes:commit`, `changes:revert`.

Closes #16.

## Test plan

- [x] `pnpm turbo test` — 403 core tests pass (23 new for the changes plugin)
- [x] `pnpm turbo type-check` — clean
- [x] `pnpm turbo lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm lodestar` — clean (only preexisting warnings in `apps/playground/src/main.tsx`)
- [ ] Manual: install the plugin in the playground, edit a cell, verify the blue triangle appears; call `grid.getPlugin('changes').revert()` in devtools and confirm the cell reverts.
- [ ] Manual: edit a cell, call `.commit()`, verify the triangle clears and a follow-up edit tracks against the committed value.
- [ ] Manual: with both `history` and `changes` installed, revert and press Ctrl+Z — the reverted cells should come back to their dirty state as one undoable step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)