### PR TITLE
feat: wai-aria grid pattern + screen-reader announcements (#17)

### DIFF
--- a/.changeset/a11y-aria-grid.md
+++ b/.changeset/a11y-aria-grid.md
@@ -1,0 +1,50 @@
+---
+'@gridsmith/core': minor
+'@gridsmith/react': minor
+---
+
+Implement the WAI-ARIA 1.2 grid pattern and screen-reader announcements.
+
+**Roles and indices (both renderers):**
+
+- Grid root advertises `role="grid"` with `aria-rowcount` (counting
+  header rows + pinned top + data + pinned bottom) and `aria-colcount`.
+- Header container uses `role="rowgroup"`; each header row is wrapped
+  in `role="row"` with a 1-based `aria-rowindex`.
+- Header cells keep `role="columnheader"` and gain `aria-colindex`,
+  plus `aria-colspan` / `aria-rowspan` for grouped columns.
+- Data rows carry `role="row"` + `aria-rowindex` offset by header depth
+  and pinned-top count; pinned rows use correct absolute indices.
+- Every cell renders `role="gridcell"`, a stable `id`, and
+  `aria-colindex`. Non-editable columns add `aria-readonly="true"`.
+
+**Active cell tracking:**
+
+- Grid root sets `aria-activedescendant` to the focused cell's id so
+  screen readers announce focus movement without stealing DOM focus
+  from the grid container (container-focus model).
+
+**Validation:**
+
+- The validation plugin's cell decorator now contributes
+  `aria-invalid="true"` on error states (pending validations are not
+  flagged), so renderers automatically surface the attribute on
+  affected cells.
+
+**Live regions:**
+
+- Each grid creates a polite (`role="status"`) and an assertive
+  (`role="alert"`) live region as siblings of the grid root. A
+  150 ms-debounced announcer reports sort/filter summaries, paste
+  dimensions, and validation errors without interrupting navigation.
+- New exports from `@gridsmith/core`: `buildCellId`,
+  `buildPinnedCellId`, `computeRowCount`, `createAnnouncer`,
+  `dataRowAriaIndex`, `headerRowAriaIndex`, `nextGridInstanceId`,
+  `pinnedBottomAriaIndex`, `pinnedTopAriaIndex`, plus the `Announcer`
+  and `AriaRowCountInput` types. The id format produced by
+  `buildCellId` / `buildPinnedCellId` is considered part of the public
+  contract — future format changes will ship as a breaking change.
+- New helper in `@gridsmith/react`: `useGridAnnouncements` wires a
+  grid's lifecycle events to polite/assertive live-region refs. The
+  React adapter derives its grid id from `useId()` so cell ids are
+  stable across SSR hydration.

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,6 +8,7 @@
     "e2e:ui": "playwright test --ui"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.10.0",
     "@playwright/test": "^1.50.0"
   }
 }

--- a/e2e/tests/a11y.spec.ts
+++ b/e2e/tests/a11y.spec.ts
@@ -1,0 +1,64 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+const GRID_SELECTOR = '.gs-grid';
+
+async function scanGrid(page: Parameters<typeof AxeBuilder>[0]['page']) {
+  // `color-contrast` is scoped to the playground's palette, which is a demo
+  // theme — not shipped in the published packages. Regressing the grid
+  // markup should not fail on demo colors, so we disable only that rule.
+  return new AxeBuilder({ page }).include(GRID_SELECTOR).disableRules(['color-contrast']).analyze();
+}
+
+test.describe('Grid accessibility', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.locator(GRID_SELECTOR).first().waitFor();
+  });
+
+  test('no serious/critical axe violations on default render', async ({ page }) => {
+    const results = await scanGrid(page);
+    const blocking = results.violations.filter(
+      (v) => v.impact === 'serious' || v.impact === 'critical',
+    );
+    expect(blocking, JSON.stringify(blocking, null, 2)).toEqual([]);
+  });
+
+  test('grid exposes role=grid with row/col counts', async ({ page }) => {
+    const grid = page.locator(GRID_SELECTOR).first();
+    await expect(grid).toHaveAttribute('role', 'grid');
+    await expect(grid).toHaveAttribute('aria-rowcount', /^\d+$/);
+    await expect(grid).toHaveAttribute('aria-colcount', /^\d+$/);
+  });
+
+  test('cells expose role=gridcell with aria-colindex', async ({ page }) => {
+    const firstCell = page.locator(`${GRID_SELECTOR} .gs-cell`).first();
+    await expect(firstCell).toHaveAttribute('role', 'gridcell');
+    await expect(firstCell).toHaveAttribute('aria-colindex', /^\d+$/);
+  });
+
+  test('clicking a sortable header updates the polite live region', async ({ page }) => {
+    const grid = page.locator(GRID_SELECTOR).first();
+    const politeRegion = page.locator('[aria-live="polite"]').first();
+    await expect(politeRegion).toBeAttached();
+
+    const sortableHeader = grid.locator('.gs-header-cell--sortable').first();
+    await sortableHeader.click();
+
+    await expect(politeRegion).toHaveText(/Sorted by/i, { timeout: 2000 });
+  });
+
+  test('no serious/critical axe violations after a sort is applied', async ({ page }) => {
+    const grid = page.locator(GRID_SELECTOR).first();
+    await grid.locator('.gs-header-cell--sortable').first().click();
+    await expect(grid.locator('[aria-sort="ascending"], [aria-sort="descending"]')).toHaveCount(1, {
+      timeout: 2000,
+    });
+
+    const results = await scanGrid(page);
+    const blocking = results.violations.filter(
+      (v) => v.impact === 'serious' || v.impact === 'critical',
+    );
+    expect(blocking, JSON.stringify(blocking, null, 2)).toEqual([]);
+  });
+});

--- a/packages/core/src/aria.spec.ts
+++ b/packages/core/src/aria.spec.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  buildCellId,
+  buildPinnedCellId,
+  computeRowCount,
+  createAnnouncer,
+  dataRowAriaIndex,
+  headerRowAriaIndex,
+  nextGridInstanceId,
+  pinnedBottomAriaIndex,
+  pinnedTopAriaIndex,
+} from './aria';
+
+describe('aria helpers', () => {
+  describe('index math', () => {
+    it('computeRowCount sums all logical rows', () => {
+      expect(computeRowCount({ headerDepth: 2, pinnedTop: 1, rowCount: 10, pinnedBottom: 1 })).toBe(
+        14,
+      );
+      expect(computeRowCount({ headerDepth: 1, pinnedTop: 0, rowCount: 0, pinnedBottom: 0 })).toBe(
+        1,
+      );
+    });
+
+    it('dataRowAriaIndex is 1-based after headers + pinned top', () => {
+      expect(dataRowAriaIndex(0, 2, 3)).toBe(6);
+      expect(dataRowAriaIndex(5, 1, 0)).toBe(7);
+    });
+
+    it('pinnedTopAriaIndex offsets by header depth', () => {
+      expect(pinnedTopAriaIndex(0, 2)).toBe(3);
+      expect(pinnedTopAriaIndex(1, 1)).toBe(3);
+    });
+
+    it('pinnedBottomAriaIndex sits after data rows', () => {
+      expect(pinnedBottomAriaIndex(0, 2, 1, 10)).toBe(14);
+      expect(pinnedBottomAriaIndex(2, 1, 0, 5)).toBe(9);
+    });
+
+    it('headerRowAriaIndex is 1-based', () => {
+      expect(headerRowAriaIndex(0)).toBe(1);
+      expect(headerRowAriaIndex(3)).toBe(4);
+    });
+  });
+
+  describe('id builders', () => {
+    it('nextGridInstanceId returns monotonically increasing ids', () => {
+      const a = nextGridInstanceId();
+      const b = nextGridInstanceId();
+      expect(a).toMatch(/^gs-\d+$/);
+      expect(b).toMatch(/^gs-\d+$/);
+      expect(a).not.toBe(b);
+    });
+
+    it('buildCellId composes safe id strings', () => {
+      expect(buildCellId('gs-1', 0, 'name')).toBe('gs-1-r0-cname');
+      // colId with invalid CSS selector chars gets sanitized
+      expect(buildCellId('gs-1', 3, 'user.name[0]')).toBe('gs-1-r3-cuser_name_0_');
+    });
+
+    it('buildPinnedCellId encodes top/bottom + data index', () => {
+      expect(buildPinnedCellId('gs-1', 'top', 4, 'age')).toBe('gs-1-pt4-cage');
+      expect(buildPinnedCellId('gs-1', 'bottom', 99, 'x.y')).toBe('gs-1-pb99-cx_y');
+    });
+  });
+
+  describe('createAnnouncer', () => {
+    let target: HTMLDivElement;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      target = document.createElement('div');
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('debounces and writes the last pending message', async () => {
+      const announcer = createAnnouncer(target, 100);
+      announcer.announce('first');
+      announcer.announce('second');
+      expect(target.textContent).toBe('');
+
+      vi.advanceTimersByTime(100);
+      // Flush microtasks for the queueMicrotask in the announcer.
+      await Promise.resolve();
+      expect(target.textContent).toBe('second');
+    });
+
+    it('allows a follow-up announcement after the first flush', async () => {
+      const announcer = createAnnouncer(target, 50);
+      announcer.announce('hello');
+      vi.advanceTimersByTime(50);
+      await Promise.resolve();
+      expect(target.textContent).toBe('hello');
+
+      announcer.announce('world');
+      vi.advanceTimersByTime(50);
+      await Promise.resolve();
+      expect(target.textContent).toBe('world');
+    });
+
+    it('destroy() cancels a pending announcement and clears text', async () => {
+      const announcer = createAnnouncer(target, 100);
+      announcer.announce('one');
+      announcer.destroy();
+      expect(target.textContent).toBe('');
+
+      vi.advanceTimersByTime(200);
+      await Promise.resolve();
+      // Destroyed announcer should not write after the timer fires.
+      expect(target.textContent).toBe('');
+
+      // Subsequent announces are no-ops once destroyed.
+      announcer.announce('two');
+      vi.advanceTimersByTime(200);
+      await Promise.resolve();
+      expect(target.textContent).toBe('');
+    });
+
+    it('destroy() during the microtask gap does not write', async () => {
+      const announcer = createAnnouncer(target, 10);
+      announcer.announce('pending');
+      vi.advanceTimersByTime(10);
+      // Do NOT flush microtasks yet — destroy before the queued microtask runs.
+      announcer.destroy();
+      await Promise.resolve();
+      expect(target.textContent).toBe('');
+    });
+  });
+});

--- a/packages/core/src/aria.ts
+++ b/packages/core/src/aria.ts
@@ -1,0 +1,107 @@
+// ARIA helpers for the WAI-ARIA 1.2 grid pattern.
+//
+// The grid's aria-rowcount includes header rows per spec; first data row's
+// aria-rowindex is `headerDepth + pinnedTop + 1` (1-based).
+
+export interface AriaRowCountInput {
+  headerDepth: number;
+  pinnedTop: number;
+  rowCount: number;
+  pinnedBottom: number;
+}
+
+export function computeRowCount({
+  headerDepth,
+  pinnedTop,
+  rowCount,
+  pinnedBottom,
+}: AriaRowCountInput): number {
+  return headerDepth + pinnedTop + rowCount + pinnedBottom;
+}
+
+export function dataRowAriaIndex(viewRow: number, headerDepth: number, pinnedTop: number): number {
+  return headerDepth + pinnedTop + viewRow + 1;
+}
+
+export function pinnedTopAriaIndex(offset: number, headerDepth: number): number {
+  return headerDepth + offset + 1;
+}
+
+export function pinnedBottomAriaIndex(
+  offset: number,
+  headerDepth: number,
+  pinnedTop: number,
+  rowCount: number,
+): number {
+  return headerDepth + pinnedTop + rowCount + offset + 1;
+}
+
+export function headerRowAriaIndex(rowIndex: number): number {
+  return rowIndex + 1;
+}
+
+let cellIdCounter = 0;
+export function nextGridInstanceId(): string {
+  return `gs-${++cellIdCounter}`;
+}
+
+export function buildCellId(gridId: string, viewRow: number, colId: string): string {
+  return `${gridId}-r${viewRow}-c${sanitizeColId(colId)}`;
+}
+
+export function buildPinnedCellId(
+  gridId: string,
+  position: 'top' | 'bottom',
+  dataIndex: number,
+  colId: string,
+): string {
+  return `${gridId}-p${position[0]}${dataIndex}-c${sanitizeColId(colId)}`;
+}
+
+function sanitizeColId(colId: string): string {
+  return colId.replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
+// ─── Announcer ───────────────────────────────────────────
+
+export interface Announcer {
+  announce(message: string): void;
+  destroy(): void;
+}
+
+export function createAnnouncer(target: HTMLElement, delay = 150): Announcer {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let pending: string | null = null;
+  let destroyed = false;
+
+  function flush() {
+    timer = null;
+    if (destroyed || pending === null) return;
+    // Reset to empty then set — some screen readers skip duplicate text.
+    target.textContent = '';
+    const msg = pending;
+    pending = null;
+    // Microtask delay so the empty-text reset is observed before the new text.
+    queueMicrotask(() => {
+      if (destroyed) return;
+      target.textContent = msg;
+    });
+  }
+
+  return {
+    announce(message: string) {
+      if (destroyed) return;
+      pending = message;
+      if (timer !== null) return;
+      timer = setTimeout(flush, delay);
+    },
+    destroy() {
+      destroyed = true;
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      target.textContent = '';
+    },
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,6 +56,20 @@ export {
 } from './column-group';
 export type { HeaderCell } from './column-group';
 
+// ARIA helpers
+export {
+  buildCellId,
+  buildPinnedCellId,
+  computeRowCount,
+  createAnnouncer,
+  dataRowAriaIndex,
+  headerRowAriaIndex,
+  nextGridInstanceId,
+  pinnedBottomAriaIndex,
+  pinnedTopAriaIndex,
+} from './aria';
+export type { Announcer, AriaRowCountInput } from './aria';
+
 // Types
 export type {
   CellValue,

--- a/packages/core/src/renderer.spec.ts
+++ b/packages/core/src/renderer.spec.ts
@@ -324,4 +324,123 @@ describe('createRenderer', () => {
     const header = container.querySelector('.gs-header') as HTMLElement;
     expect(header.style.height).toBe('40px');
   });
+
+  // ─── ARIA grid pattern ────────────────────────────────
+
+  it('sets role="grid" and row/col counts on the root', () => {
+    const grid = createGrid({ data: makeRows(12), columns });
+    renderer = createRenderer({ container, grid });
+
+    const root = container.querySelector('.gs-grid') as HTMLElement;
+    expect(root.getAttribute('role')).toBe('grid');
+    // 1 header row + 12 data rows = 13
+    expect(root.getAttribute('aria-rowcount')).toBe('13');
+    expect(root.getAttribute('aria-colcount')).toBe('3');
+  });
+
+  it('sets role="row" + aria-rowindex on header and data rows', () => {
+    const grid = createGrid({ data: makeRows(5), columns });
+    renderer = createRenderer({ container, grid });
+
+    const headerRow = container.querySelector('.gs-header-row') as HTMLElement;
+    expect(headerRow.getAttribute('role')).toBe('row');
+    expect(headerRow.getAttribute('aria-rowindex')).toBe('1');
+
+    const firstDataRow = container.querySelector('.gs-row') as HTMLElement;
+    expect(firstDataRow.getAttribute('role')).toBe('row');
+    // headerDepth=1, viewIndex=0 → aria-rowindex=2
+    expect(firstDataRow.getAttribute('aria-rowindex')).toBe('2');
+  });
+
+  it('offsets aria-rowindex by header depth with nested groups', () => {
+    const grouped: ColumnDef[] = [
+      {
+        id: 'person',
+        header: 'Person',
+        children: [
+          { id: 'name', header: 'Name', width: 100 },
+          { id: 'age', header: 'Age', width: 80 },
+        ],
+      },
+    ];
+    const grid = createGrid({ data: makeRows(3), columns: grouped });
+    renderer = createRenderer({ container, grid });
+
+    const root = container.querySelector('.gs-grid') as HTMLElement;
+    // headerDepth=2, 3 data rows → 5
+    expect(root.getAttribute('aria-rowcount')).toBe('5');
+
+    const firstDataRow = container.querySelector('.gs-row') as HTMLElement;
+    expect(firstDataRow.getAttribute('aria-rowindex')).toBe('3');
+  });
+
+  it('sets role="gridcell" + aria-colindex on cells', () => {
+    const grid = createGrid({ data: makeRows(3), columns });
+    renderer = createRenderer({ container, grid });
+
+    const cells = container.querySelectorAll('.gs-row:first-of-type .gs-cell');
+    expect(cells[0].getAttribute('role')).toBe('gridcell');
+    expect(cells[0].getAttribute('aria-colindex')).toBe('1');
+    expect(cells[1].getAttribute('aria-colindex')).toBe('2');
+    expect(cells[2].getAttribute('aria-colindex')).toBe('3');
+  });
+
+  it('sets aria-readonly on cells whose column has editable=false', () => {
+    const readonlyColumns: ColumnDef[] = [
+      { id: 'name', header: 'Name', width: 120, editable: false },
+      { id: 'age', header: 'Age', width: 80 },
+    ];
+    const grid = createGrid({ data: makeRows(2), columns: readonlyColumns });
+    renderer = createRenderer({ container, grid });
+
+    const firstRowCells = container.querySelectorAll('.gs-row:first-of-type .gs-cell');
+    expect(firstRowCells[0].getAttribute('aria-readonly')).toBe('true');
+    expect(firstRowCells[1].getAttribute('aria-readonly')).toBeNull();
+  });
+
+  it('sets aria-colspan on group header cells', () => {
+    const grouped: ColumnDef[] = [
+      {
+        id: 'person',
+        header: 'Person',
+        children: [
+          { id: 'name', header: 'Name', width: 100 },
+          { id: 'age', header: 'Age', width: 80 },
+        ],
+      },
+    ];
+    const grid = createGrid({ data: makeRows(2), columns: grouped });
+    renderer = createRenderer({ container, grid });
+
+    const groupCell = container.querySelector('.gs-header-cell--group') as HTMLElement;
+    expect(groupCell.getAttribute('role')).toBe('columnheader');
+    expect(groupCell.getAttribute('aria-colspan')).toBe('2');
+  });
+
+  it('adds live-region nodes as siblings of the grid root', () => {
+    const grid = createGrid({ data: makeRows(3), columns });
+    renderer = createRenderer({ container, grid });
+
+    const root = container.querySelector('.gs-grid') as HTMLElement;
+    const live = container.querySelectorAll('[aria-live]');
+    expect(live.length).toBe(2);
+    for (const region of Array.from(live)) {
+      expect(region.parentElement).toBe(container);
+      expect(root.contains(region)).toBe(false);
+    }
+    const politenesses = Array.from(live).map((el) => el.getAttribute('aria-live'));
+    expect(politenesses).toContain('polite');
+    expect(politenesses).toContain('assertive');
+  });
+
+  it('destroy() removes live regions from the container', () => {
+    const grid = createGrid({ data: makeRows(3), columns });
+    renderer = createRenderer({ container, grid });
+    expect(container.querySelectorAll('[aria-live]').length).toBe(2);
+
+    renderer.destroy();
+
+    expect(container.querySelectorAll('[aria-live]').length).toBe(0);
+    expect(container.querySelector('.gs-grid')).toBeNull();
+  });
 });

--- a/packages/core/src/renderer.spec.ts
+++ b/packages/core/src/renderer.spec.ts
@@ -3,7 +3,9 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
 import { createGrid } from './grid';
 import { createRenderer, type RendererInstance } from './renderer';
-import type { ColumnDef, Row } from './types';
+import { createSelectionPlugin } from './selection';
+import type { ColumnDef, Row, SelectionPluginApi, ValidationPluginApi } from './types';
+import { createValidationPlugin } from './validation';
 
 // ─── Helpers ──────────────────────────────────────────────
 
@@ -442,5 +444,124 @@ describe('createRenderer', () => {
 
     expect(container.querySelectorAll('[aria-live]').length).toBe(0);
     expect(container.querySelector('.gs-grid')).toBeNull();
+  });
+
+  // ─── Announcements & activedescendant ─────────────────
+
+  it('announces "Sort cleared" when the sort state is emptied', async () => {
+    vi.useFakeTimers();
+    try {
+      const grid = createGrid({
+        data: makeRows(5),
+        columns: [
+          { id: 'name', header: 'Name', width: 120, sortable: true },
+          { id: 'age', header: 'Age', width: 80 },
+        ],
+      });
+      renderer = createRenderer({ container, grid });
+
+      // Apply a sort, then clear it.
+      grid.sortState.set([{ columnId: 'name', direction: 'asc' }]);
+      flushRAF();
+      grid.sortState.set([]);
+      flushRAF();
+
+      const polite = container.querySelector('[aria-live="polite"]') as HTMLElement;
+      await vi.advanceTimersByTimeAsync(200);
+      await Promise.resolve();
+      expect(polite.textContent).toBe('Sort cleared');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('announces filter row count on filter:change', async () => {
+    vi.useFakeTimers();
+    try {
+      const grid = createGrid({ data: makeRows(10), columns });
+      renderer = createRenderer({ container, grid });
+
+      grid.filterState.set([{ columnId: 'city', operator: 'eq', value: 'Seoul' }]);
+      flushRAF();
+
+      const polite = container.querySelector('[aria-live="polite"]') as HTMLElement;
+      await vi.advanceTimersByTimeAsync(200);
+      await Promise.resolve();
+      expect(polite.textContent).toMatch(/^Showing \d+ rows$/);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('updates aria-activedescendant from selection:change and clears it when cleared', () => {
+    const selection = createSelectionPlugin();
+    const grid = createGrid({ data: makeRows(5), columns, plugins: [selection] });
+    renderer = createRenderer({ container, grid });
+    const root = container.querySelector('.gs-grid') as HTMLElement;
+    const api = grid.getPlugin<SelectionPluginApi>('selection')!;
+
+    // No active cell → attr absent.
+    expect(root.getAttribute('aria-activedescendant')).toBeNull();
+
+    api.selectCell({ row: 0, col: 'name' });
+    const activeId = root.getAttribute('aria-activedescendant');
+    expect(activeId).toBeTruthy();
+    const active = document.getElementById(activeId!);
+    expect(active?.classList.contains('gs-cell')).toBe(true);
+
+    api.clear();
+    expect(root.getAttribute('aria-activedescendant')).toBeNull();
+  });
+
+  it('omits aria-activedescendant when the active cell is outside the rendered range', () => {
+    const selection = createSelectionPlugin();
+    // 10 000 rows so the active cell far below the viewport is not rendered.
+    const grid = createGrid({ data: makeRows(10_000), columns, plugins: [selection] });
+    renderer = createRenderer({ container, grid, rowHeight: 32 });
+
+    const root = container.querySelector('.gs-grid') as HTMLElement;
+    const api = grid.getPlugin<SelectionPluginApi>('selection')!;
+    api.selectCell({ row: 9000, col: 'name' });
+
+    expect(root.getAttribute('aria-activedescendant')).toBeNull();
+  });
+
+  it('announces "Invalid: …" on newly-added validation errors', async () => {
+    vi.useFakeTimers();
+    try {
+      const invalidColumns: ColumnDef[] = [
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          width: 120,
+          validate: (v) => (typeof v === 'string' && v.length > 0) || 'Name required',
+        },
+      ];
+      const grid = createGrid({
+        data: [{ name: 'Alice' }, { name: 'Bob' }],
+        columns: invalidColumns,
+        plugins: [createValidationPlugin()],
+      });
+      renderer = createRenderer({ container, grid });
+
+      const validation = grid.getPlugin<ValidationPluginApi>('validation')!;
+      validation.validateCell(0, 'name', '');
+
+      const assertive = container.querySelector('[aria-live="assertive"]') as HTMLElement;
+      await vi.advanceTimersByTimeAsync(200);
+      await Promise.resolve();
+      expect(assertive.textContent).toBe('Invalid: Name required');
+
+      // Re-reporting the same error should not re-announce — the key diff
+      // filters it out, leaving the live region untouched for 150ms.
+      assertive.textContent = '';
+      validation.validateCell(0, 'name', '');
+      await vi.advanceTimersByTimeAsync(200);
+      await Promise.resolve();
+      expect(assertive.textContent).toBe('');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1,6 +1,22 @@
+import {
+  buildCellId,
+  computeRowCount,
+  createAnnouncer,
+  dataRowAriaIndex,
+  headerRowAriaIndex,
+  nextGridInstanceId,
+  type Announcer,
+} from './aria';
 import { buildHeaderRows, getHeaderDepth, type HeaderCell } from './column-group';
 import type { Unsubscribe } from './signal';
-import type { GridInstance, ColumnDef, VisibleRange } from './types';
+import type {
+  ColumnDef,
+  GridInstance,
+  SelectionPluginApi,
+  SelectionState,
+  SortState,
+  VisibleRange,
+} from './types';
 import {
   computeColumnLayout,
   calculateVisibleRange,
@@ -46,6 +62,7 @@ const CLS = {
   canvas: 'gs-canvas',
   row: 'gs-row',
   cell: 'gs-cell',
+  srOnly: 'gs-sr-only',
 } as const;
 
 // ─── Renderer Implementation ──────────────────────────────
@@ -75,23 +92,39 @@ export function createRenderer(options: RendererOptions): RendererInstance {
   //   </div>
   // </div>
 
+  const gridInstanceId = nextGridInstanceId();
+
   const root = el('div', CLS.root);
   const header = el('div', CLS.header);
   const viewport = el('div', CLS.viewport);
   const canvas = el('div', CLS.canvas);
+  const politeLiveRegion = el('div', CLS.srOnly);
+  const assertiveLiveRegion = el('div', CLS.srOnly);
 
   let headerDepth = Math.max(1, getHeaderDepth(grid.columnDefs.get()));
   let totalHeaderHeight = headerRowHeight * headerDepth;
 
+  root.id = gridInstanceId;
+  root.setAttribute('role', 'grid');
   root.style.cssText = 'position:relative;overflow:hidden;';
+  header.setAttribute('role', 'rowgroup');
   header.style.cssText = `position:relative;height:${totalHeaderHeight}px;overflow:hidden;`;
+  viewport.setAttribute('role', 'rowgroup');
   viewport.style.cssText = 'position:relative;overflow:auto;will-change:transform;';
   canvas.style.cssText = 'position:relative;';
+
+  configureLiveRegion(politeLiveRegion, 'status', 'polite');
+  configureLiveRegion(assertiveLiveRegion, 'alert', 'assertive');
 
   viewport.appendChild(canvas);
   root.appendChild(header);
   root.appendChild(viewport);
+  container.appendChild(politeLiveRegion);
+  container.appendChild(assertiveLiveRegion);
   container.appendChild(root);
+
+  const politeAnnouncer: Announcer = createAnnouncer(politeLiveRegion);
+  const assertiveAnnouncer: Announcer = createAnnouncer(assertiveLiveRegion);
 
   // ─── State ────────────────────────────────────────────
 
@@ -120,6 +153,49 @@ export function createRenderer(options: RendererOptions): RendererInstance {
     // Viewport height = container height minus header
     const containerHeight = container.clientHeight;
     viewport.style.height = `${containerHeight - totalHeaderHeight}px`;
+
+    updateAriaCounts();
+  }
+
+  function updateAriaCounts() {
+    const rowCount = computeRowCount({
+      headerDepth,
+      pinnedTop: 0,
+      rowCount: grid.rowCount,
+      pinnedBottom: 0,
+    });
+    const visibleLeafColumns = grid.columns.get().filter((c) => c.visible !== false).length;
+    root.setAttribute('aria-rowcount', String(rowCount));
+    root.setAttribute('aria-colcount', String(visibleLeafColumns));
+  }
+
+  function updateActiveDescendant(state: SelectionState) {
+    const active = state.activeCell;
+    if (!active) {
+      root.removeAttribute('aria-activedescendant');
+      return;
+    }
+    const id = buildCellId(gridInstanceId, active.row, active.col);
+    const target = document.getElementById(id);
+    if (target && root.contains(target)) {
+      root.setAttribute('aria-activedescendant', id);
+    } else {
+      root.removeAttribute('aria-activedescendant');
+    }
+  }
+
+  function announceSort(sort: SortState) {
+    if (sort.length === 0) {
+      politeAnnouncer.announce('Sort cleared');
+      return;
+    }
+    const columnIds = grid.columns.get();
+    const parts = sort.map((entry) => {
+      const col = columnIds.find((c) => c.id === entry.columnId);
+      const label = col?.header ?? entry.columnId;
+      return `${label} ${entry.direction === 'asc' ? 'ascending' : 'descending'}`;
+    });
+    politeAnnouncer.announce(`Sorted by ${parts.join(', ')}`);
   }
 
   // ─── Header Rendering ────────────────────────────────
@@ -131,6 +207,10 @@ export function createRenderer(options: RendererOptions): RendererInstance {
     const rows = buildHeaderRows(tree);
 
     for (let r = 0; r < rows.length; r++) {
+      const rowEl = el('div', CLS.headerRow);
+      rowEl.setAttribute('role', 'row');
+      rowEl.setAttribute('aria-rowindex', String(headerRowAriaIndex(r)));
+      rowEl.style.cssText = 'position:absolute;inset:0;pointer-events:none;';
       for (const cellDef of rows[r]) {
         const { left, width } = spanExtent(cellDef, columnLayout, leafColumns);
         if (width === 0) continue; // all spanned columns are hidden
@@ -139,11 +219,16 @@ export function createRenderer(options: RendererOptions): RendererInstance {
           cellDef.isLeaf ? CLS.headerCell : `${CLS.headerCell} ${CLS.headerGroup}`,
         );
         cell.textContent = cellDef.column.header;
+        cell.setAttribute('role', 'columnheader');
+        cell.setAttribute('aria-colindex', String(cellDef.colStart + 1));
+        if (cellDef.colSpan > 1) cell.setAttribute('aria-colspan', String(cellDef.colSpan));
+        if (cellDef.rowSpan > 1) cell.setAttribute('aria-rowspan', String(cellDef.rowSpan));
         const top = r * headerRowHeight;
         const height = cellDef.rowSpan * headerRowHeight;
-        cell.style.cssText = `position:absolute;left:${left}px;top:${top}px;width:${width}px;height:${height}px;box-sizing:border-box;overflow:hidden;`;
-        header.appendChild(cell);
+        cell.style.cssText = `position:absolute;left:${left}px;top:${top}px;width:${width}px;height:${height}px;box-sizing:border-box;overflow:hidden;pointer-events:auto;`;
+        rowEl.appendChild(cell);
       }
+      header.appendChild(rowEl);
     }
   }
 
@@ -169,6 +254,8 @@ export function createRenderer(options: RendererOptions): RendererInstance {
     row.innerHTML = '';
     row.style.cssText = `position:absolute;top:${viewIndex * config.rowHeight}px;left:0;width:${columnLayout.totalWidth}px;height:${config.rowHeight}px;`;
     row.dataset.viewIndex = String(viewIndex);
+    row.setAttribute('role', 'row');
+    row.setAttribute('aria-rowindex', String(dataRowAriaIndex(viewIndex, headerDepth, 0)));
 
     for (let c = range.colStart; c <= range.colEnd; c++) {
       const col = columns[c];
@@ -178,6 +265,10 @@ export function createRenderer(options: RendererOptions): RendererInstance {
       const value = grid.getCell(viewIndex, col.id);
       cell.textContent = formatCellValue(value);
       cell.style.cssText = `position:absolute;left:${columnLayout.offsets[c]}px;width:${columnLayout.widths[c]}px;height:${config.rowHeight}px;box-sizing:border-box;overflow:hidden;`;
+      cell.id = buildCellId(gridInstanceId, viewIndex, col.id);
+      cell.setAttribute('role', 'gridcell');
+      cell.setAttribute('aria-colindex', String(c + 1));
+      if (col.editable === false) cell.setAttribute('aria-readonly', 'true');
 
       // Apply cell decorations
       const decorations = grid.getCellDecorations(viewIndex, col.id);
@@ -275,6 +366,10 @@ export function createRenderer(options: RendererOptions): RendererInstance {
     }
 
     prevRange = range;
+
+    // Refresh active-descendant now that the new cell ids are in the DOM.
+    const selectionApi = grid.getPlugin<SelectionPluginApi>('selection');
+    if (selectionApi) updateActiveDescendant(selectionApi.getState());
   }
 
   function clearAllRows() {
@@ -353,10 +448,11 @@ export function createRenderer(options: RendererOptions): RendererInstance {
   );
 
   unsubs.push(
-    grid.subscribe('sort:change', () => {
+    grid.subscribe('sort:change', ({ sort }) => {
       clearAllRows();
       prevRange = null;
       scheduleRender();
+      announceSort(sort);
     }),
   );
 
@@ -365,6 +461,26 @@ export function createRenderer(options: RendererOptions): RendererInstance {
       clearAllRows();
       prevRange = null;
       scheduleRender();
+      politeAnnouncer.announce(`Showing ${grid.rowCount} rows`);
+    }),
+  );
+
+  unsubs.push(
+    grid.subscribe('selection:change', (state) => {
+      updateActiveDescendant(state);
+    }),
+  );
+
+  // Key-based diff catches the clear-and-add-in-same-tick case that a
+  // simple count comparison would miss.
+  let prevErrorKeys = new Set<string>();
+  unsubs.push(
+    grid.subscribe('validation:change', ({ errors }) => {
+      const nonPending = errors.filter((e) => e.state !== 'pending');
+      const currentKeys = new Set(nonPending.map((e) => `${e.dataIndex}:${e.columnId}`));
+      const newlyAdded = nonPending.find((e) => !prevErrorKeys.has(`${e.dataIndex}:${e.columnId}`));
+      if (newlyAdded) assertiveAnnouncer.announce(`Invalid: ${newlyAdded.message}`);
+      prevErrorKeys = currentKeys;
     }),
   );
 
@@ -403,10 +519,19 @@ export function createRenderer(options: RendererOptions): RendererInstance {
       for (const unsub of unsubs) unsub();
       unsubs.length = 0;
 
+      politeAnnouncer.destroy();
+      assertiveAnnouncer.destroy();
+
       clearAllRows();
       rowPool.length = 0;
 
       container.removeChild(root);
+      if (politeLiveRegion.parentNode === container) {
+        container.removeChild(politeLiveRegion);
+      }
+      if (assertiveLiveRegion.parentNode === container) {
+        container.removeChild(assertiveLiveRegion);
+      }
     },
   };
 }
@@ -417,6 +542,14 @@ function el(tag: string, className: string): HTMLDivElement {
   const element = document.createElement(tag) as HTMLDivElement;
   element.className = className;
   return element;
+}
+
+function configureLiveRegion(node: HTMLElement, role: string, politeness: 'polite' | 'assertive') {
+  node.setAttribute('role', role);
+  node.setAttribute('aria-live', politeness);
+  node.setAttribute('aria-atomic', 'true');
+  node.style.cssText =
+    'position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;';
 }
 
 function formatCellValue(value: string | number | boolean | Date | null | undefined): string {

--- a/packages/core/src/validation.spec.ts
+++ b/packages/core/src/validation.spec.ts
@@ -345,6 +345,7 @@ describe('validation plugin', () => {
       expect(decorations[0].className).toBe('gs-cell--invalid');
       expect(decorations[0].attributes?.['data-validation-state']).toBe('invalid');
       expect(decorations[0].attributes?.['data-validation-message']).toBe('Required');
+      expect(decorations[0].attributes?.['aria-invalid']).toBe('true');
     });
 
     it('decorates a pending cell with the validating class', () => {
@@ -362,6 +363,8 @@ describe('validation plugin', () => {
       const decorations = grid.getCellDecorations(0, 'name');
       expect(decorations).toHaveLength(1);
       expect(decorations[0].className).toBe('gs-cell--validating');
+      // Pending is not an error yet — aria-invalid should stay off.
+      expect(decorations[0].attributes?.['aria-invalid']).toBeUndefined();
       d.resolve(true);
     });
   });

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -374,6 +374,7 @@ export function createValidationPlugin(): GridPlugin {
           return { className: 'gs-cell--validating', attributes };
         }
         attributes['data-validation-message'] = err.message;
+        attributes['aria-invalid'] = 'true';
         // Native `title` is the fallback tooltip — the React adapter renders a
         // styled overlay on top of it, but consumers without the overlay still
         // see the error message on hover with zero extra code.

--- a/packages/react/src/grid.spec.tsx
+++ b/packages/react/src/grid.spec.tsx
@@ -636,4 +636,82 @@ describe('Grid', () => {
       expect(first?.getAttribute('draggable')).toBe('true');
     });
   });
+
+  describe('ARIA grid pattern', () => {
+    it('sets role="grid" with row/col counts on the root', () => {
+      const { container } = render(<Grid data={data} columns={columns} />);
+      const root = container.querySelector('.gs-grid') as HTMLElement;
+      expect(root.getAttribute('role')).toBe('grid');
+      // 1 header row + 2 data rows = 3
+      expect(root.getAttribute('aria-rowcount')).toBe('3');
+      expect(root.getAttribute('aria-colcount')).toBe('2');
+    });
+
+    it('applies aria-rowindex/colindex to header and cells', () => {
+      const { container } = render(<Grid data={data} columns={columns} />);
+      const headerCells = container.querySelectorAll('.gs-header-cell');
+      expect(headerCells[0].getAttribute('aria-rowindex')).toBe('1');
+      expect(headerCells[0].getAttribute('aria-colindex')).toBe('1');
+      expect(headerCells[1].getAttribute('aria-colindex')).toBe('2');
+
+      const firstRow = container.querySelector('.gs-row') as HTMLElement;
+      expect(firstRow.getAttribute('role')).toBe('row');
+      expect(firstRow.getAttribute('aria-rowindex')).toBe('2');
+
+      const cells = firstRow.querySelectorAll('.gs-cell');
+      expect(cells[0].getAttribute('role')).toBe('gridcell');
+      expect(cells[0].getAttribute('aria-colindex')).toBe('1');
+    });
+
+    it('sets aria-colspan on group headers', () => {
+      const grouped: GridColumnDef[] = [
+        {
+          id: 'person',
+          header: 'Person',
+          children: [
+            { id: 'name', header: 'Name' },
+            { id: 'age', header: 'Age' },
+          ],
+        },
+      ];
+      const { container } = render(<Grid data={data} columns={grouped} />);
+      const group = container.querySelector('.gs-header-cell--group') as HTMLElement;
+      expect(group.getAttribute('role')).toBe('columnheader');
+      expect(group.getAttribute('aria-colspan')).toBe('2');
+    });
+
+    it('sets aria-readonly on cells whose column is not editable', () => {
+      const cols: GridColumnDef[] = [
+        { id: 'name', header: 'Name', editable: false },
+        { id: 'age', header: 'Age' },
+      ];
+      const { container } = render(<Grid data={data} columns={cols} />);
+      const firstRow = container.querySelector('.gs-row') as HTMLElement;
+      const rowCells = firstRow.querySelectorAll('.gs-cell');
+      expect(rowCells[0].getAttribute('aria-readonly')).toBe('true');
+      expect(rowCells[1].getAttribute('aria-readonly')).toBeNull();
+    });
+
+    it('tracks aria-activedescendant against the focused cell id', () => {
+      const { container } = render(<Grid data={data} columns={columns} />);
+      const root = container.querySelector('.gs-grid') as HTMLElement;
+      const firstCell = container.querySelector('.gs-cell') as HTMLElement;
+
+      fireEvent.mouseDown(firstCell);
+      fireEvent.mouseUp(firstCell);
+
+      const activeId = root.getAttribute('aria-activedescendant');
+      expect(activeId).toBeTruthy();
+      expect(firstCell.id).toBe(activeId);
+    });
+
+    it('renders polite and assertive live regions', () => {
+      const { container } = render(<Grid data={data} columns={columns} />);
+      const live = container.querySelectorAll('[aria-live]');
+      expect(live.length).toBe(2);
+      const politeness = Array.from(live).map((el) => el.getAttribute('aria-live'));
+      expect(politeness).toContain('polite');
+      expect(politeness).toContain('assertive');
+    });
+  });
 });

--- a/packages/react/src/grid.tsx
+++ b/packages/react/src/grid.tsx
@@ -13,19 +13,26 @@ import {
   type Row,
   type SelectionPluginApi,
   type VisibleRange,
+  buildCellId,
   buildHeaderRows,
+  buildPinnedCellId,
   calculateVisibleRange,
   columnStructureKey,
   computeColumnLayout,
+  computeRowCount,
   createClipboardPlugin,
   createEditingPlugin,
   createFillHandlePlugin,
   createHistoryPlugin,
   createSelectionPlugin,
   createValidationPlugin,
+  dataRowAriaIndex,
   flattenColumns,
   getHeaderDepth,
   getTotalHeight,
+  headerRowAriaIndex,
+  pinnedBottomAriaIndex,
+  pinnedTopAriaIndex,
   DEFAULT_CONFIG,
 } from '@gridsmith/core';
 import {
@@ -34,6 +41,7 @@ import {
   memo,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -44,10 +52,23 @@ import { FilterPopover } from './filter-popover';
 import { cycleSortState } from './header-sort';
 import type { GridProps } from './types';
 import { useGrid } from './use-grid';
+import { useGridAnnouncements } from './use-grid-announcements';
 import { useGridSelection } from './use-grid-selection';
 import { useSignalValue } from './use-signal';
 
 // ─── Helpers ───────────────────────────────────────────────
+
+const SR_ONLY_STYLE: CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0,0,0,0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};
 
 function formatCellValue(value: CellValue): string {
   if (value == null) return '';
@@ -315,6 +336,13 @@ export const Grid = memo(function Grid({
   const viewportRef = useRef<HTMLDivElement>(null);
   const headerInnerRef = useRef<HTMLDivElement>(null);
   const gridRootRef = useRef<HTMLDivElement>(null);
+  const politeLiveRef = useRef<HTMLDivElement>(null);
+  const assertiveLiveRef = useRef<HTMLDivElement>(null);
+  // `useId()` is SSR-stable across server render → client hydration so the
+  // cell `id`s and `aria-activedescendant` references line up on first paint.
+  // `:` is not valid in CSS id selectors, so strip it for the prefix.
+  const reactId = useId();
+  const gridId = `gs-${reactId.replace(/:/g, '')}`;
   const [visibleRange, setVisibleRange] = useState<VisibleRange | null>(null);
 
   // Refs for latest values so the scroll handler never goes stale
@@ -578,6 +606,8 @@ export const Grid = memo(function Grid({
 
   const currentPinnedTop = useSignalValue(grid.pinnedTopRows);
   const currentPinnedBottom = useSignalValue(grid.pinnedBottomRows);
+  const pinnedTopCount = currentPinnedTop.length;
+  const pinnedBottomCount = currentPinnedBottom.length;
 
   // ─── Render header ─────────────────────────────────────
 
@@ -627,6 +657,10 @@ export const Grid = memo(function Grid({
           aria-sort={
             sortInfo ? (sortInfo.direction === 'asc' ? 'ascending' : 'descending') : 'none'
           }
+          aria-rowindex={headerRowAriaIndex(rowIndex)}
+          aria-colindex={cell.colStart + 1}
+          aria-rowspan={cell.rowSpan > 1 ? cell.rowSpan : undefined}
+          aria-readonly={col.editable === false ? true : undefined}
           data-col={col.id}
           draggable={draggable}
           onDragStart={draggable ? (e) => handleDragStart(e, col.id, i) : undefined}
@@ -755,6 +789,9 @@ export const Grid = memo(function Grid({
           key={`group:${cell.column.id}:${cell.colStart}`}
           className="gs-header-cell gs-header-cell--group"
           role="columnheader"
+          aria-rowindex={headerRowAriaIndex(rowIndex)}
+          aria-colindex={cell.colStart + 1}
+          aria-colspan={cell.colSpan > 1 ? cell.colSpan : undefined}
           data-col-group={cell.column.id}
           style={{
             position: 'absolute',
@@ -781,9 +818,25 @@ export const Grid = memo(function Grid({
   const headerCells = useMemo(() => {
     const out: ReactNode[] = [];
     for (let r = 0; r < headerRows.length; r++) {
+      const cells: ReactNode[] = [];
       for (const cell of headerRows[r]) {
-        out.push(cell.isLeaf ? renderLeafHeaderCell(cell, r) : renderGroupHeaderCell(cell, r));
+        const node = cell.isLeaf ? renderLeafHeaderCell(cell, r) : renderGroupHeaderCell(cell, r);
+        if (node) cells.push(node);
       }
+      out.push(
+        // `display: contents` keeps the wrapper out of the layout so the
+        // already-absolutely-positioned header cells resolve against the
+        // outer relative container, but preserves the `role="row"` node in
+        // the accessibility tree.
+        <div
+          key={`header-row-${r}`}
+          role="row"
+          aria-rowindex={headerRowAriaIndex(r)}
+          style={{ display: 'contents' }}
+        >
+          {cells}
+        </div>,
+      );
     }
     return out;
   }, [headerRows, renderLeafHeaderCell, renderGroupHeaderCell]);
@@ -882,8 +935,12 @@ export const Grid = memo(function Grid({
         cells.push(
           <div
             key={col.id}
+            id={buildCellId(gridId, r, col.id)}
             className={cellClassName}
             style={cellStyle}
+            role="gridcell"
+            aria-colindex={c + 1}
+            aria-readonly={col.editable === false ? true : undefined}
             data-row={r}
             data-col={col.id}
             {...attrs}
@@ -897,6 +954,8 @@ export const Grid = memo(function Grid({
         <div
           key={r}
           className="gs-row"
+          role="row"
+          aria-rowindex={dataRowAriaIndex(r, headerDepth, pinnedTopCount)}
           style={{
             position: 'absolute',
             top: r * rowHeight,
@@ -921,6 +980,9 @@ export const Grid = memo(function Grid({
     rowHeight,
     dataVersion,
     selection,
+    gridId,
+    headerDepth,
+    pinnedTopCount,
   ]);
 
   // ─── Cell interaction handlers ──────────────────────────
@@ -1679,7 +1741,11 @@ export const Grid = memo(function Grid({
           cells.push(
             <div
               key={col.id}
+              id={buildPinnedCellId(gridId, position, dataIdx, col.id)}
               className={cellClassName}
+              role="gridcell"
+              aria-colindex={c + 1}
+              aria-readonly={col.editable === false ? true : undefined}
               style={{
                 position: 'absolute',
                 left: columnLayout.offsets[c],
@@ -1696,10 +1762,17 @@ export const Grid = memo(function Grid({
           );
         }
 
+        const rowAriaIndex =
+          position === 'top'
+            ? pinnedTopAriaIndex(i, headerDepth)
+            : pinnedBottomAriaIndex(i, headerDepth, pinnedTopCount, totalRows);
+
         rows.push(
           <div
             key={dataIdx}
             className={`gs-row gs-row--pinned gs-row--pinned-${position}`}
+            role="row"
+            aria-rowindex={rowAriaIndex}
             data-pinned={position}
             data-data-index={dataIdx}
             style={{
@@ -1716,6 +1789,7 @@ export const Grid = memo(function Grid({
       return (
         <div
           className={`gs-pinned-rows gs-pinned-rows--${position}`}
+          role="rowgroup"
           style={{
             position: 'relative',
             flexShrink: 0,
@@ -1729,7 +1803,17 @@ export const Grid = memo(function Grid({
         </div>
       );
     },
-    [currentColumns, columnLayout, rowHeight, grid, dataVersion],
+    [
+      currentColumns,
+      columnLayout,
+      rowHeight,
+      grid,
+      dataVersion,
+      gridId,
+      headerDepth,
+      pinnedTopCount,
+      totalRows,
+    ],
   );
 
   const pinnedTopRowsEl = useMemo(
@@ -1742,114 +1826,154 @@ export const Grid = memo(function Grid({
     [renderPinnedRows, currentPinnedBottom],
   );
 
+  // ─── ARIA grid counts + live-region announcements ──────
+
+  const ariaRowCount = computeRowCount({
+    headerDepth,
+    pinnedTop: pinnedTopCount,
+    rowCount: totalRows,
+    pinnedBottom: pinnedBottomCount,
+  });
+  const ariaColCount = currentColumns.filter((c) => c.visible !== false).length;
+  const activeDescendantId = focusedCell
+    ? buildCellId(gridId, focusedCell.row, focusedCell.col)
+    : undefined;
+
+  useGridAnnouncements(grid, politeLiveRef, assertiveLiveRef);
+
   // ─── JSX ───────────────────────────────────────────────
 
   return (
-    <div
-      className={className ? `gs-grid ${className}` : 'gs-grid'}
-      style={{
-        position: 'relative',
-        overflow: 'hidden',
-        display: 'flex',
-        flexDirection: 'column',
-      }}
-      tabIndex={0}
-      onKeyDown={handleKeyDown}
-      ref={gridRootRef}
-    >
+    <>
       <div
-        className="gs-header"
+        ref={politeLiveRef}
+        className="gs-sr-only"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        style={SR_ONLY_STYLE}
+      />
+      <div
+        ref={assertiveLiveRef}
+        className="gs-sr-only"
+        role="alert"
+        aria-live="assertive"
+        aria-atomic="true"
+        style={SR_ONLY_STYLE}
+      />
+      <div
+        id={gridId}
+        className={className ? `gs-grid ${className}` : 'gs-grid'}
+        role="grid"
+        aria-rowcount={ariaRowCount}
+        aria-colcount={ariaColCount}
+        aria-activedescendant={activeDescendantId}
         style={{
-          // `overflow: visible` so the filter popover (which anchors at the
-          // header cell's left edge and drops below the header) is not
-          // clipped by the header element's bounding box.
           position: 'relative',
-          height: totalHeaderHeight,
-          flexShrink: 0,
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column',
         }}
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        ref={gridRootRef}
       >
         <div
-          ref={headerInnerRef}
+          className="gs-header"
+          role="rowgroup"
           style={{
+            // `overflow: visible` so the filter popover (which anchors at the
+            // header cell's left edge and drops below the header) is not
+            // clipped by the header element's bounding box.
             position: 'relative',
-            width: columnLayout.totalWidth,
             height: totalHeaderHeight,
+            flexShrink: 0,
           }}
         >
-          {headerCells}
-          {filterPopover}
+          <div
+            ref={headerInnerRef}
+            style={{
+              position: 'relative',
+              width: columnLayout.totalWidth,
+              height: totalHeaderHeight,
+            }}
+          >
+            {headerCells}
+            {filterPopover}
+          </div>
         </div>
-      </div>
-      {pinnedTopRowsEl}
-      <div
-        ref={viewportRef}
-        className="gs-viewport"
-        style={{
-          position: 'relative',
-          overflow: 'auto',
-          flex: 1,
-        }}
-        onMouseDown={handleCellMouseDown}
-        onMouseMove={handleCellMouseMove}
-        onMouseUp={handleCellMouseUp}
-        onMouseLeave={handleCellMouseUp}
-        onClick={handleCellClick}
-        onDoubleClick={handleDoubleClick}
-      >
+        {pinnedTopRowsEl}
         <div
-          className="gs-canvas"
+          ref={viewportRef}
+          className="gs-viewport"
+          role="rowgroup"
           style={{
             position: 'relative',
-            height: totalHeight,
-            width: columnLayout.totalWidth,
+            overflow: 'auto',
+            flex: 1,
           }}
+          onMouseDown={handleCellMouseDown}
+          onMouseMove={handleCellMouseMove}
+          onMouseUp={handleCellMouseUp}
+          onMouseLeave={handleCellMouseUp}
+          onClick={handleCellClick}
+          onDoubleClick={handleDoubleClick}
         >
-          {rowElements}
-          {editorOverlay}
-          {fillPreviewRect && (
-            <div
-              className="gs-fill-preview"
-              aria-hidden="true"
-              style={{
-                position: 'absolute',
-                left: fillPreviewRect.left,
-                top: fillPreviewRect.top,
-                width: fillPreviewRect.width,
-                height: fillPreviewRect.height,
-                border: '1px dashed #1a73e8',
-                boxSizing: 'border-box',
-                pointerEvents: 'none',
-                zIndex: 4,
-              }}
-            />
-          )}
-          {fillHandleVisible && activeRangeRect && (
-            <div
-              className="gs-fill-handle"
-              role="presentation"
-              aria-hidden="true"
-              onPointerDown={handleFillHandlePointerDown}
-              onPointerMove={handleFillHandlePointerMove}
-              onPointerUp={handleFillHandlePointerUp}
-              onPointerCancel={handleFillHandlePointerUp}
-              style={{
-                position: 'absolute',
-                left: activeRangeRect.left + activeRangeRect.width - 4,
-                top: activeRangeRect.top + activeRangeRect.height - 4,
-                width: 8,
-                height: 8,
-                background: '#1a73e8',
-                border: '1px solid white',
-                boxSizing: 'border-box',
-                cursor: 'crosshair',
-                zIndex: 5,
-                touchAction: 'none',
-              }}
-            />
-          )}
+          <div
+            className="gs-canvas"
+            style={{
+              position: 'relative',
+              height: totalHeight,
+              width: columnLayout.totalWidth,
+            }}
+          >
+            {rowElements}
+            {editorOverlay}
+            {fillPreviewRect && (
+              <div
+                className="gs-fill-preview"
+                aria-hidden="true"
+                style={{
+                  position: 'absolute',
+                  left: fillPreviewRect.left,
+                  top: fillPreviewRect.top,
+                  width: fillPreviewRect.width,
+                  height: fillPreviewRect.height,
+                  border: '1px dashed #1a73e8',
+                  boxSizing: 'border-box',
+                  pointerEvents: 'none',
+                  zIndex: 4,
+                }}
+              />
+            )}
+            {fillHandleVisible && activeRangeRect && (
+              <div
+                className="gs-fill-handle"
+                role="presentation"
+                aria-hidden="true"
+                onPointerDown={handleFillHandlePointerDown}
+                onPointerMove={handleFillHandlePointerMove}
+                onPointerUp={handleFillHandlePointerUp}
+                onPointerCancel={handleFillHandlePointerUp}
+                style={{
+                  position: 'absolute',
+                  left: activeRangeRect.left + activeRangeRect.width - 4,
+                  top: activeRangeRect.top + activeRangeRect.height - 4,
+                  width: 8,
+                  height: 8,
+                  background: '#1a73e8',
+                  border: '1px solid white',
+                  boxSizing: 'border-box',
+                  cursor: 'crosshair',
+                  zIndex: 5,
+                  touchAction: 'none',
+                }}
+              />
+            )}
+          </div>
         </div>
+        {pinnedBottomRowsEl}
       </div>
-      {pinnedBottomRowsEl}
-    </div>
+    </>
   );
 });

--- a/packages/react/src/use-grid-announcements.spec.tsx
+++ b/packages/react/src/use-grid-announcements.spec.tsx
@@ -1,0 +1,237 @@
+import {
+  createClipboardPlugin,
+  createEditingPlugin,
+  createGrid,
+  createSelectionPlugin,
+  createValidationPlugin,
+  type ClipboardPluginApi,
+  type ColumnDef,
+  type SelectionPluginApi,
+  type ValidationPluginApi,
+} from '@gridsmith/core';
+import { act, renderHook } from '@testing-library/react';
+import { useRef, type RefObject } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useGridAnnouncements } from './use-grid-announcements';
+
+const columns: ColumnDef[] = [
+  { id: 'name', header: 'Name', type: 'text' },
+  { id: 'age', header: 'Age', type: 'number' },
+];
+
+type Setup = {
+  grid: ReturnType<typeof createGrid>;
+  politeEl: HTMLDivElement;
+  assertiveEl: HTMLDivElement;
+  unmount: () => void;
+};
+
+function renderWith(
+  grid: ReturnType<typeof createGrid>,
+  options: { attachPolite?: boolean; attachAssertive?: boolean } = {},
+): Setup {
+  const politeEl = document.createElement('div');
+  const assertiveEl = document.createElement('div');
+  const { attachPolite = true, attachAssertive = true } = options;
+
+  const { unmount } = renderHook(() => {
+    const politeRef = useRef<HTMLDivElement | null>(attachPolite ? politeEl : null);
+    const assertiveRef = useRef<HTMLDivElement | null>(attachAssertive ? assertiveEl : null);
+    useGridAnnouncements(
+      grid,
+      politeRef as RefObject<HTMLElement | null>,
+      assertiveRef as RefObject<HTMLElement | null>,
+    );
+  });
+
+  return { grid, politeEl, assertiveEl, unmount };
+}
+
+async function flushAnnouncer() {
+  await vi.advanceTimersByTimeAsync(200);
+  await Promise.resolve();
+}
+
+describe('useGridAnnouncements', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('announces sort application and clearing via the polite region', async () => {
+    const grid = createGrid({
+      data: [{ name: 'b', age: 1 }],
+      columns: [
+        { id: 'name', header: 'Name', type: 'text', sortable: true },
+        { id: 'age', header: 'Age', type: 'number' },
+      ],
+    });
+    const { politeEl, unmount } = renderWith(grid);
+
+    act(() => {
+      grid.sortState.set([{ columnId: 'name', direction: 'asc' }]);
+    });
+    await flushAnnouncer();
+    expect(politeEl.textContent).toBe('Sorted by Name ascending');
+
+    act(() => {
+      grid.sortState.set([]);
+    });
+    await flushAnnouncer();
+    expect(politeEl.textContent).toBe('Sort cleared');
+
+    unmount();
+  });
+
+  it('falls back to the column id when no header is available', async () => {
+    const grid = createGrid({
+      data: [{ name: 'a', age: 2 }],
+      columns: [
+        { id: 'name', header: '', type: 'text', sortable: true },
+        { id: 'age', header: 'Age', type: 'number' },
+      ],
+    });
+    const { politeEl, unmount } = renderWith(grid);
+
+    act(() => {
+      grid.sortState.set([{ columnId: 'missing', direction: 'desc' }]);
+    });
+    await flushAnnouncer();
+    expect(politeEl.textContent).toBe('Sorted by missing descending');
+
+    unmount();
+  });
+
+  it('announces filter row counts', async () => {
+    const grid = createGrid({
+      data: [
+        { name: 'a', age: 1 },
+        { name: 'b', age: 2 },
+      ],
+      columns,
+    });
+    const { politeEl, unmount } = renderWith(grid);
+
+    act(() => {
+      grid.filterState.set([{ columnId: 'name', operator: 'eq', value: 'a' }]);
+    });
+    await flushAnnouncer();
+    expect(politeEl.textContent).toMatch(/^Showing \d+ rows$/);
+
+    unmount();
+  });
+
+  it('announces clipboard paste shape with singular/plural wording', async () => {
+    // Stub the browser clipboard so `paste()` resolves a deterministic
+    // matrix. Each test case swaps `readText` to the payload it wants.
+    let clipboardText = '';
+    vi.stubGlobal('navigator', {
+      ...globalThis.navigator,
+      clipboard: {
+        readText: () => Promise.resolve(clipboardText),
+      },
+    });
+
+    try {
+      const grid = createGrid({
+        data: [
+          { name: 'a', age: 1 },
+          { name: 'b', age: 2 },
+        ],
+        columns,
+        plugins: [createSelectionPlugin(), createClipboardPlugin()],
+      });
+      const clipboard = grid.getPlugin<ClipboardPluginApi>('clipboard')!;
+      const selection = grid.getPlugin<SelectionPluginApi>('selection')!;
+      const { politeEl, unmount } = renderWith(grid);
+
+      selection.selectCell({ row: 0, col: 'name' });
+      clipboardText = 'solo';
+      await act(async () => {
+        await clipboard.paste();
+      });
+      await flushAnnouncer();
+      expect(politeEl.textContent).toBe('Pasted 1 row by 1 column');
+
+      selection.selectCell({ row: 0, col: 'name' });
+      clipboardText = 'a\tb\nc\td';
+      await act(async () => {
+        await clipboard.paste();
+      });
+      await flushAnnouncer();
+      expect(politeEl.textContent).toBe('Pasted 2 rows by 2 columns');
+
+      unmount();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('announces newly-added validation errors only once per key', async () => {
+    const grid = createGrid({
+      data: [{ name: 'Alice', age: 30 }],
+      columns: [
+        {
+          id: 'name',
+          header: 'Name',
+          type: 'text',
+          validate: (v) => (typeof v === 'string' && v.length > 0) || 'Name required',
+        },
+        { id: 'age', header: 'Age', type: 'number' },
+      ],
+      plugins: [createEditingPlugin(), createValidationPlugin()],
+    });
+    const validation = grid.getPlugin<ValidationPluginApi>('validation')!;
+    const { assertiveEl, unmount } = renderWith(grid);
+
+    act(() => {
+      validation.validateCell(0, 'name', '');
+    });
+    await flushAnnouncer();
+    expect(assertiveEl.textContent).toBe('Invalid: Name required');
+
+    // Same error repeated — key-diff should suppress.
+    assertiveEl.textContent = '';
+    act(() => {
+      validation.validateCell(0, 'name', '');
+    });
+    await flushAnnouncer();
+    expect(assertiveEl.textContent).toBe('');
+
+    unmount();
+  });
+
+  it('no-ops when either ref is not attached to an element', () => {
+    const grid = createGrid({ data: [{ name: 'a', age: 1 }], columns });
+    const { politeEl, assertiveEl, unmount } = renderWith(grid, { attachAssertive: false });
+
+    act(() => {
+      grid.sortState.set([]);
+    });
+    expect(politeEl.textContent).toBe('');
+    expect(assertiveEl.textContent).toBe('');
+    unmount();
+  });
+
+  it('tears down subscriptions on unmount (no announcements after)', async () => {
+    const grid = createGrid({
+      data: [{ name: 'a', age: 1 }],
+      columns: [
+        { id: 'name', header: 'Name', type: 'text', sortable: true },
+        { id: 'age', header: 'Age', type: 'number' },
+      ],
+    });
+    const { politeEl, unmount } = renderWith(grid);
+
+    unmount();
+    act(() => {
+      grid.sortState.set([{ columnId: 'name', direction: 'asc' }]);
+    });
+    await flushAnnouncer();
+    expect(politeEl.textContent).toBe('');
+  });
+});

--- a/packages/react/src/use-grid-announcements.ts
+++ b/packages/react/src/use-grid-announcements.ts
@@ -1,0 +1,66 @@
+import type { GridInstance } from '@gridsmith/core';
+import { createAnnouncer } from '@gridsmith/core';
+import { useEffect, type RefObject } from 'react';
+
+/**
+ * Wires a grid instance to two aria-live regions: a polite one for sort /
+ * filter / paste summaries and an assertive one for validation errors. Both
+ * refs should point to visually hidden containers rendered by the caller.
+ */
+export function useGridAnnouncements(
+  grid: GridInstance,
+  politeRef: RefObject<HTMLElement | null>,
+  assertiveRef: RefObject<HTMLElement | null>,
+): void {
+  useEffect(() => {
+    const politeEl = politeRef.current;
+    const assertiveEl = assertiveRef.current;
+    if (!politeEl || !assertiveEl) return;
+
+    const polite = createAnnouncer(politeEl);
+    const assertive = createAnnouncer(assertiveEl);
+
+    // Key-based diff catches the clear-and-add-in-same-tick case that a
+    // simple count comparison would miss.
+    let prevErrorKeys = new Set<string>();
+
+    const unsubs = [
+      grid.subscribe('sort:change', ({ sort }) => {
+        if (sort.length === 0) {
+          polite.announce('Sort cleared');
+          return;
+        }
+        const columns = grid.columns.get();
+        const parts = sort.map((entry) => {
+          const col = columns.find((c) => c.id === entry.columnId);
+          const label = col?.header ?? entry.columnId;
+          return `${label} ${entry.direction === 'asc' ? 'ascending' : 'descending'}`;
+        });
+        polite.announce(`Sorted by ${parts.join(', ')}`);
+      }),
+      grid.subscribe('filter:change', () => {
+        polite.announce(`Showing ${grid.rowCount} rows`);
+      }),
+      grid.subscribe('clipboard:paste', ({ rows, cols }) => {
+        polite.announce(
+          `Pasted ${rows} ${rows === 1 ? 'row' : 'rows'} by ${cols} ${cols === 1 ? 'column' : 'columns'}`,
+        );
+      }),
+      grid.subscribe('validation:change', ({ errors }) => {
+        const nonPending = errors.filter((e) => e.state !== 'pending');
+        const currentKeys = new Set(nonPending.map((e) => `${e.dataIndex}:${e.columnId}`));
+        const newlyAdded = nonPending.find(
+          (e) => !prevErrorKeys.has(`${e.dataIndex}:${e.columnId}`),
+        );
+        if (newlyAdded) assertive.announce(`Invalid: ${newlyAdded.message}`);
+        prevErrorKeys = currentKeys;
+      }),
+    ];
+
+    return () => {
+      for (const u of unsubs) u();
+      polite.destroy();
+      assertive.destroy();
+    };
+  }, [grid, politeRef, assertiveRef]);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
 
   e2e:
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.10.0
+        version: 4.11.2(playwright-core@1.59.1)
       '@playwright/test':
         specifier: ^1.50.0
         version: 1.59.1
@@ -333,6 +336,11 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@axe-core/playwright@4.11.2':
+    resolution: {integrity: sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -2041,6 +2049,10 @@ packages:
 
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
+
+  axe-core@4.11.3:
+    resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
+    engines: {node: '>=4'}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -3888,6 +3900,11 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
+  '@axe-core/playwright@4.11.2(playwright-core@1.59.1)':
+    dependencies:
+      axe-core: 4.11.3
+      playwright-core: 1.59.1
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -5424,6 +5441,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+
+  axe-core@4.11.3: {}
 
   balanced-match@4.0.4: {}
 


### PR DESCRIPTION
## Summary

- Implements the WAI-ARIA 1.2 grid pattern across both vanilla (`@gridsmith/core`) and React (`@gridsmith/react`) renderers: `role=grid/row/gridcell/columnheader/rowgroup`, `aria-rowcount`/`aria-colcount` (header rows included), `aria-rowindex`/`aria-colindex` (with `aria-colspan`/`aria-rowspan` on grouped headers), plus `aria-readonly` and `aria-invalid` on cells.
- Tracks focus via `aria-activedescendant` using stable cell ids (`nextGridInstanceId` for vanilla, `useId()` for SSR stability in React), with an off-screen guard that omits the attribute when the target isn't in the DOM.
- Renders two visually hidden live regions (polite `role=status`, assertive `role=alert`) as siblings of the grid root — avoids the `aria-required-children` axe violation — and wires a 150 ms debounced announcer to `sort:change`, `filter:change`, `clipboard:paste`, and `validation:change`. Validation uses a key-based diff so clear-then-add in the same tick is announced.
- Adds `@axe-core/playwright` e2e suite scoped to `.gs-grid`: checks no serious/critical violations on default + post-sort render, asserts `role=grid`/counts, cell `role=gridcell`/`aria-colindex`, and live-region text after a header sort click.

## Test plan

- [x] `pnpm turbo test` — core + react unit suites pass (including new `aria.spec.ts`, `use-grid-announcements.spec.tsx`, and renderer branch coverage)
- [x] `pnpm turbo type-check && pnpm turbo lint`
- [x] `pnpm format:check`
- [x] Coverage gates: core branches 80.84% ✅, react branches 80.58% ✅
- [ ] `pnpm turbo test --filter=e2e` — Playwright + axe on playground
- [ ] Manual screen-reader smoke: VoiceOver (macOS) grid-mode navigation reads column header + row/col position; NVDA browse mode traverses the grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)