### PR TITLE
feat: v1.0 release prep — readmes, announcement, 1.0.0 changeset (#21)

### DIFF
--- a/.changeset/v1-0-0-release.md
+++ b/.changeset/v1-0-0-release.md
@@ -1,0 +1,17 @@
+---
+'@gridsmith/core': major
+'@gridsmith/react': major
+---
+
+Gridsmith 1.0 — first stable release.
+
+Marks the public API surface as stable. Includes the headless core with reactive
+state, plugin system, and event bus; the DOM renderer with row + column
+virtualization; the React adapter with `<Grid />` and hooks; and the full
+Excel-grade editing engine — selection, clipboard (TSV + HTML), fill handle
+with pattern detection, undo/redo, validation, sort/filter, column
+resize/reorder/pinning, row pinning, multi-level group headers, async data
+source with infinite scroll, change tracking, keyboard navigation with IME
+support, and the WAI-ARIA grid pattern with screen-reader announcements.
+
+See the individual changesets in this release for per-feature details.

--- a/README.md
+++ b/README.md
@@ -4,16 +4,18 @@
 
 [![CI](https://github.com/retemper/gridsmith/actions/workflows/ci.yml/badge.svg)](https://github.com/retemper/gridsmith/actions/workflows/ci.yml)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![@gridsmith/core](https://img.shields.io/npm/v/@gridsmith/core.svg?label=%40gridsmith%2Fcore)](https://www.npmjs.com/package/@gridsmith/core)
+[![@gridsmith/react](https://img.shields.io/npm/v/@gridsmith/react.svg?label=%40gridsmith%2Freact)](https://www.npmjs.com/package/@gridsmith/react)
 
 ---
 
 ## Packages
 
-| Package                              | Description                                           | npm |
-| ------------------------------------ | ----------------------------------------------------- | --- |
-| [`@gridsmith/core`](packages/core)   | Headless core — state, editing engine, virtualization | -   |
-| [`@gridsmith/react`](packages/react) | React adapter                                         | -   |
-| [`@gridsmith/ui`](packages/ui)       | Preset UI components                                  | -   |
+| Package                              | Description                                           | npm                                                                                                         |
+| ------------------------------------ | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| [`@gridsmith/core`](packages/core)   | Headless core — state, editing engine, virtualization | [![npm](https://img.shields.io/npm/v/@gridsmith/core.svg)](https://www.npmjs.com/package/@gridsmith/core)   |
+| [`@gridsmith/react`](packages/react) | React adapter                                         | [![npm](https://img.shields.io/npm/v/@gridsmith/react.svg)](https://www.npmjs.com/package/@gridsmith/react) |
+| [`@gridsmith/ui`](packages/ui)       | Preset UI components                                  | _planned for 1.x_                                                                                           |
 
 ## Quick Start
 
@@ -30,9 +32,29 @@ import { Grid } from '@gridsmith/react';
     { id: 'name', header: 'Name', editor: 'text' },
     { id: 'price', header: 'Price', editor: 'number' },
   ]}
-  editable
 />;
 ```
+
+## Features
+
+| Capability                                                               | Status |
+| ------------------------------------------------------------------------ | ------ |
+| Cell editing (text / number / select / checkbox / date + custom editors) | ✅     |
+| Range selection (single + multi-range, row, column)                      | ✅     |
+| Excel-compatible clipboard (TSV + HTML copy / paste / cut)               | ✅     |
+| Fill handle with pattern detection (numbers, dates, sequences)           | ✅     |
+| Undo / redo (Command pattern with batch grouping)                        | ✅     |
+| Sync + async cell validation                                             | ✅     |
+| Sort / filter (controlled or uncontrolled)                               | ✅     |
+| Column resize, reorder, and left/right pinning                           | ✅     |
+| Top / bottom row pinning                                                 | ✅     |
+| Multi-level group headers                                                | ✅     |
+| Async data source + infinite scroll                                      | ✅     |
+| Change tracking (dirty cells, batch commit / revert)                     | ✅     |
+| Full keyboard nav with IME-safe composition                              | ✅     |
+| WAI-ARIA 1.2 grid pattern + screen-reader announcements                  | ✅     |
+| Row + column virtualization (1M-row scrolling)                           | ✅     |
+| MIT licensed — no Pro tier, ever                                         | ✅     |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Editing Engine       (selection, clipboard, fill, undo, validate)
 Headless Core        (state, columns, rows, sort, filter)
 Renderer             (DOM v1, Canvas v2)
 Virtualization       (rows + columns)
-Data Source           (sync, async, streaming)
+Data Source          (sync, async)
 ```
 
 ## Contributing

--- a/docs/announcements/v1.0.md
+++ b/docs/announcements/v1.0.md
@@ -11,13 +11,19 @@ pnpm add @gridsmith/react
 ```tsx
 import { Grid } from '@gridsmith/react';
 
-<Grid
-  data={rows}
-  columns={[
-    { id: 'name', header: 'Name', editor: 'text' },
-    { id: 'price', header: 'Price', editor: 'number' },
-  ]}
-/>;
+const rows = [
+  { name: 'Aria', price: 12 },
+  { name: 'Beam', price: 34 },
+];
+
+const columns = [
+  { id: 'name', header: 'Name', editor: 'text' as const },
+  { id: 'price', header: 'Price', editor: 'number' as const },
+];
+
+export function App() {
+  return <Grid data={rows} columns={columns} />;
+}
 ```
 
 That's the whole hello-world. Editing, selection, clipboard, fill handle, undo/redo, and keyboard nav are on by default.
@@ -35,7 +41,7 @@ Gridsmith's bet is that those features deserve to be free and well-built. The Pr
 - **Editors** — text, number, select, checkbox, date, plus `defineEditor` for custom ones
 - **Range selection** — single + multi-range, row select, column select, Shift / Cmd / Ctrl modifiers
 - **Clipboard** — Excel-compatible TSV **and** HTML on copy, both directions on paste, multi-range cut/delete
-- **Fill handle** — pattern detection for numbers (linear), dates (day / week / month), and string sequences ("Q1, Q2, ...")
+- **Fill handle** — pattern detection for arithmetic progressions, dates (advanced by day), day/month names (Mon/Monday, Jan/January), prefix-number strings ("Q1, Q2, …"), and registered custom lists
 - **Undo / redo** — Command pattern with batch grouping; one Cmd+Z per logical action, not per cell
 - **Validation** — sync and async validators, visual error markers, configurable revert/keep modes
 - **Keyboard nav** — Arrow / Tab / Shift+Tab / Home / End / Ctrl+Arrow / Ctrl+Home / Ctrl+End / PageUp / PageDown. IME-safe — Enter and Tab don't prematurely commit during Korean / Japanese / Chinese composition.
@@ -52,13 +58,13 @@ Gridsmith's bet is that those features deserve to be free and well-built. The Pr
 - Row + column virtualization, fixed-height row mode for O(1) position math
 - Column resize, reorder, pin (left/right)
 - Row pin (top/bottom)
-- 1M-row scrolling at 60fps in our benchmark harness
+- 1M-row virtualization with a ≥60fps scroll target — see [`apps/benchmark`](https://github.com/retemper/gridsmith/tree/main/apps/benchmark) to run the comparison locally
 
 ### Accessibility
 
 - WAI-ARIA 1.2 grid pattern — proper roles, indices, and pinned-region semantics
-- Screen-reader announcer for selection / edit / validation events
-- Verified against VoiceOver and NVDA
+- Polite + assertive live regions; 150 ms-debounced announcer reports sort/filter, paste dimensions, and validation errors
+- Container-focus model with `aria-activedescendant` so screen readers track focus without it leaving the grid root
 
 ### Architecture
 

--- a/docs/announcements/v1.0.md
+++ b/docs/announcements/v1.0.md
@@ -1,0 +1,109 @@
+# Gridsmith 1.0 — the MIT-licensed Handsontable
+
+> Excel-grade editing, modern DX, built for millions of rows. MIT. No Pro tier, ever.
+
+**TL;DR.** We just shipped Gridsmith 1.0 — an MIT-licensed React data grid with the editing experience teams actually want from a spreadsheet: range selection, Excel-compatible clipboard (TSV + HTML), fill handle with pattern detection, undo/redo, sync + async validation, sort/filter, column resize/reorder/pinning, multi-level group headers, async data with infinite scroll, full keyboard nav with IME safety, and the WAI-ARIA grid pattern with screen-reader announcements. Headless core + React adapter, plugin-based, virtualized for 1M rows.
+
+```bash
+pnpm add @gridsmith/react
+```
+
+```tsx
+import { Grid } from '@gridsmith/react';
+
+<Grid
+  data={rows}
+  columns={[
+    { id: 'name', header: 'Name', editor: 'text' },
+    { id: 'price', header: 'Price', editor: 'number' },
+  ]}
+/>;
+```
+
+That's the whole hello-world. Editing, selection, clipboard, fill handle, undo/redo, and keyboard nav are on by default.
+
+## Why another data grid
+
+The grid market is split. AG Grid and Handsontable have great editing UX, but the parts most teams reach for sit behind a commercial license. Open-source grids are usually data-display first — virtualized, sortable, filterable, but the cell-editing story stops at "click, type, commit." Spreadsheet-style work — paste a 200×20 block from Excel, drag the fill handle, hit Cmd+Z three times, see a validation error inline — gets reinvented per app.
+
+Gridsmith's bet is that those features deserve to be free and well-built. The Pro/Community split makes sense for vendors; it doesn't have to be the only option for users.
+
+## What's in 1.0
+
+### Editing engine
+
+- **Editors** — text, number, select, checkbox, date, plus `defineEditor` for custom ones
+- **Range selection** — single + multi-range, row select, column select, Shift / Cmd / Ctrl modifiers
+- **Clipboard** — Excel-compatible TSV **and** HTML on copy, both directions on paste, multi-range cut/delete
+- **Fill handle** — pattern detection for numbers (linear), dates (day / week / month), and string sequences ("Q1, Q2, ...")
+- **Undo / redo** — Command pattern with batch grouping; one Cmd+Z per logical action, not per cell
+- **Validation** — sync and async validators, visual error markers, configurable revert/keep modes
+- **Keyboard nav** — Arrow / Tab / Shift+Tab / Home / End / Ctrl+Arrow / Ctrl+Home / Ctrl+End / PageUp / PageDown. IME-safe — Enter and Tab don't prematurely commit during Korean / Japanese / Chinese composition.
+
+### Data
+
+- **Sort & filter** — controlled or uncontrolled, custom comparators, multi-column sort
+- **Async data source** — `createAsyncDataPlugin({ source })`. Page-keyed dedupe, abortable fetches, generation counter for sort/filter transitions, skeleton-friendly cell decoration
+- **Change tracking** — dirty cells, batch commit, batch revert
+- **Multi-level group headers** — nested column trees that span correctly above leaf columns
+
+### Layout
+
+- Row + column virtualization, fixed-height row mode for O(1) position math
+- Column resize, reorder, pin (left/right)
+- Row pin (top/bottom)
+- 1M-row scrolling at 60fps in our benchmark harness
+
+### Accessibility
+
+- WAI-ARIA 1.2 grid pattern — proper roles, indices, and pinned-region semantics
+- Screen-reader announcer for selection / edit / validation events
+- Verified against VoiceOver and NVDA
+
+### Architecture
+
+Layered:
+
+```
+Framework Adapters   (@gridsmith/react)
+Editing Engine       (selection, clipboard, fill, undo, validate)
+Headless Core        (state, columns, rows, sort, filter)
+Renderer             (DOM)
+Virtualization       (rows + columns)
+Data Source          (sync, async)
+```
+
+Selection, clipboard, fill handle, undo/redo, validation, async data, and change tracking are independent **plugins**. Drop the ones you don't need; write your own against the same plugin contract.
+
+## Performance targets
+
+From [`apps/benchmark`](https://github.com/retemper/gridsmith/tree/main/apps/benchmark) — run vs AG Grid Community, Handsontable, and Glide Data Grid:
+
+| Metric        | Target   |
+| ------------- | -------- |
+| First render  | < 100 ms |
+| Scroll        | ≥ 60 fps |
+| Bundle (gzip) | < 40 KB  |
+
+The benchmark site is open — clone the repo, run `pnpm --filter @gridsmith/benchmark dev`, pick a row count, hit **Run all**.
+
+## What's _not_ in 1.0
+
+Honest list:
+
+- **Canvas renderer.** DOM only for 1.0. The architecture has a renderer seam; canvas is on the post-1.0 roadmap.
+- **`@gridsmith/ui` presets.** The package is reserved on the npm scope but ships empty in 1.0. Default themes, header presets, and a toolbar arrive in a 1.x.
+- **Vue / Svelte / Solid adapters.** Headless core is framework-agnostic; community adapters are welcome.
+- **Pivot tables, tree data, master/detail.** Not in scope for 1.0.
+
+## Try it
+
+- npm: [`@gridsmith/react`](https://www.npmjs.com/package/@gridsmith/react), [`@gridsmith/core`](https://www.npmjs.com/package/@gridsmith/core)
+- Docs: <https://retemper.github.io/gridsmith/>
+- Repo: <https://github.com/retemper/gridsmith>
+- Examples: <https://github.com/retemper/gridsmith/tree/main/examples>
+- Roadmap: <https://github.com/orgs/retemper/projects/1>
+
+If the editing UX is what's been missing for you, file an issue with the Excel behavior you want — we'd rather track real spreadsheet workflows than guess.
+
+— the Gridsmith team

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,53 @@
+# @gridsmith/core
+
+> Headless core for the [Gridsmith](https://github.com/retemper/gridsmith) data grid — state, editing engine, virtualization. Framework-agnostic.
+
+[![npm](https://img.shields.io/npm/v/@gridsmith/core.svg)](https://www.npmjs.com/package/@gridsmith/core)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/retemper/gridsmith/blob/main/LICENSE)
+
+## Install
+
+```bash
+pnpm add @gridsmith/core
+```
+
+## What's in the box
+
+- **`createGrid(options)`** — reactive grid instance with signals, plugin host, event bus, and sort/filter index map
+- **`createRenderer(options)`** — DOM renderer with row + column virtualization
+- **Editing plugins** — `createEditingPlugin`, `createSelectionPlugin`, `createClipboardPlugin` (TSV + HTML), `createFillHandlePlugin`, `createHistoryPlugin` (Command pattern undo/redo), `createValidationPlugin` (sync + async)
+- **Data plugins** — `createAsyncDataPlugin` (infinite scroll, page-keyed dedupe, abortable fetches), `createChangesPlugin` (dirty tracking, batch commit/revert)
+- **Layout helpers** — multi-level group headers (`flattenColumns`, `buildHeaderRows`), virtualization primitives (`computeColumnLayout`, `calculateVisibleRange`)
+- **A11y helpers** — WAI-ARIA grid pattern utilities and a screen-reader announcer
+
+## Vanilla example
+
+```ts
+import { createGrid, createRenderer, createEditingPlugin } from '@gridsmith/core';
+
+const grid = createGrid({
+  data: [
+    { name: 'Aria', price: 12 },
+    { name: 'Beam', price: 34 },
+  ],
+  columns: [
+    { id: 'name', header: 'Name', editor: 'text' },
+    { id: 'price', header: 'Price', editor: 'number' },
+  ],
+  plugins: [createEditingPlugin()],
+});
+
+createRenderer({ grid, container: document.getElementById('grid')! });
+```
+
+If you're using React, reach for [`@gridsmith/react`](https://www.npmjs.com/package/@gridsmith/react) instead — it wires the renderer and plugins into a `<Grid />` component for you.
+
+## Docs
+
+- Documentation: <https://retemper.github.io/gridsmith/>
+- API reference: <https://retemper.github.io/gridsmith/api/core>
+- Source: <https://github.com/retemper/gridsmith>
+
+## License
+
+MIT © retemper

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,83 @@
+# @gridsmith/react
+
+> React adapter for [Gridsmith](https://github.com/retemper/gridsmith) — Excel-grade editing in a single `<Grid />` component.
+
+[![npm](https://img.shields.io/npm/v/@gridsmith/react.svg)](https://www.npmjs.com/package/@gridsmith/react)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/retemper/gridsmith/blob/main/LICENSE)
+
+## Install
+
+```bash
+pnpm add @gridsmith/react
+```
+
+Peer deps: `react >=18` and `react-dom >=18`. The adapter installs `@gridsmith/core` automatically.
+
+## Quick start
+
+```tsx
+import { Grid } from '@gridsmith/react';
+
+const rows = [
+  { name: 'Aria', price: 12 },
+  { name: 'Beam', price: 34 },
+];
+
+const columns = [
+  { id: 'name', header: 'Name', editor: 'text' as const },
+  { id: 'price', header: 'Price', editor: 'number' as const },
+];
+
+export function App() {
+  return <Grid data={rows} columns={columns} />;
+}
+```
+
+## What you get out of the box
+
+- **Editing** — text / number / select / checkbox / date editors, custom editors via `defineEditor`, double-click / F2 / type-to-edit, Enter/Esc/Tab semantics
+- **Selection & keyboard nav** — single + multi-range, row/column select, full arrow / Tab / Home/End / PageUp/PageDown, IME-safe composition
+- **Clipboard** — Excel-compatible TSV + HTML copy/paste/cut, multi-range
+- **Fill handle** — Excel-style pattern detection (numbers, dates, sequences)
+- **Undo/Redo** — Command pattern with batch grouping
+- **Validation** — sync + async validators with visual error markers
+- **Sort / filter** — controlled or uncontrolled
+- **Columns** — resize, reorder, pin (left/right), multi-level group headers
+- **Rows** — top/bottom pinning, fixed-height row virtualization
+- **Async data** — infinite scroll plugin with page dedupe and AbortSignal
+- **A11y** — WAI-ARIA 1.2 grid pattern + screen-reader announcements
+
+## Hooks
+
+For headless control alongside `<Grid />`:
+
+```tsx
+import { useGrid, useGridSelection, useGridClipboard } from '@gridsmith/react';
+```
+
+`useGrid`, `useGridSelection`, `useGridClipboard`, `useGridFillHandle`, `useGridValidation`, `useSignalValue`.
+
+## Custom cells
+
+```tsx
+const columns = [
+  {
+    id: 'price',
+    header: 'Price',
+    cellRenderer: ({ value }) => <strong>${value}</strong>,
+  },
+];
+```
+
+For deeper customization, write a plugin against `@gridsmith/core` and pass it via `<Grid plugins={[...]} />`.
+
+## Docs
+
+- Getting started: <https://retemper.github.io/gridsmith/guide/getting-started>
+- API reference: <https://retemper.github.io/gridsmith/api/react>
+- Examples: <https://github.com/retemper/gridsmith/tree/main/examples>
+- Source: <https://github.com/retemper/gridsmith>
+
+## License
+
+MIT © retemper

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,21 @@
+# @gridsmith/ui
+
+> Preset UI components for [Gridsmith](https://github.com/retemper/gridsmith) — opinionated themes, headers, and toolbars on top of `@gridsmith/react`.
+
+> **Status: not yet released.** This package is a placeholder reserved on the `@gridsmith` scope. The first preset components ship in a follow-up minor release. For now, use [`@gridsmith/react`](https://www.npmjs.com/package/@gridsmith/react) directly.
+
+## When ready, this package will provide
+
+- A default theme (light + dark) tuned for `<Grid />`
+- Header presets (sortable, filterable, with menu)
+- A toolbar with copy / paste / undo / redo / fill controls
+- Empty / loading / error states
+
+## Tracking
+
+- Source: <https://github.com/retemper/gridsmith>
+- Roadmap: <https://github.com/orgs/retemper/projects/1>
+
+## License
+
+MIT © retemper

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gridsmith/ui",
   "version": "0.0.0",
+  "private": true,
   "type": "module",
   "description": "Preset UI components for Gridsmith data grid",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Local prep for the **v1.0 release** (closes part of #21). All publish infra (changesets, `version.yml`, `publish.yml` with OIDC) is already in place — this PR fills in the docs/copy gaps and seeds the version bump.

- **`.changeset/v1-0-0-release.md`** — major changeset for `@gridsmith/core` and `@gridsmith/react`. Combined with the 18 existing minor changesets, the next \`changeset version\` run lands both at **1.0.0** (verified with \`pnpm changeset status\`).
- **Per-package READMEs** for `@gridsmith/core`, `@gridsmith/react`, and `@gridsmith/ui` — these are what npm shows on the package page, currently missing for all three.
- **Root README** — npm version badges, dedicated **Features** matrix, and Quick Start cleaned up. Packages table now links to npm.
- **`docs/announcements/v1.0.md`** — dev.to / Reddit / HN-flavored draft post: hello-world, why-another-grid, what's in 1.0, what's _not_ in 1.0, performance targets, links.
- **`packages/ui` marked `private: true`** — `@gridsmith/ui` only re-exports `VERSION` today. Without this flag the changesets `updateInternalDependencies: "patch"` rule was dragging it to 0.0.1 alongside the core/react bump, which would publish an effectively empty package. The package stays in the workspace and can be flipped back when real preset components land.

The README copy is grounded in the actual exports — survey of `packages/*/src/index.ts`, the changeset bodies, and `apps/benchmark/README.md` for performance numbers.

## Acceptance criteria status (#21)

- [x] **README complete** — root + per-package
- [x] **Announcement draft ready**
- [ ] **All packages published to npm** — needs a maintainer to run `version.yml` → merge the version PR → `publish.yml` runs (requires `NPM_TOKEN` secret)
- [ ] **GitHub Release created** — automated by `publish.yml` after publish

## Decision needed

`@gridsmith/ui` is marked `private: true` for 1.0. If you want to publish a placeholder package instead, drop the `private: true` and add a major changeset for `@gridsmith/ui` so it lands at 1.0.0 (not 0.0.1) — but the README in this PR already explains why I'd hold it.

## Test plan

- [x] `pnpm format:check` — clean
- [x] `pnpm turbo build` (core / react / ui) — green
- [x] `pnpm turbo type-check` (core / react / ui) — green
- [x] `pnpm changeset status` — confirms `core 0.0.0 → 1.0.0`, `react 0.0.0 → 1.0.0`, `ui 0.0.0 → 0.0.0` (skipped)
- [ ] Maintainer: configure `NPM_TOKEN` secret if not already set
- [ ] Maintainer: trigger `version.yml`, review the version PR, merge to publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)