### PR TITLE
ci: switch publish pipeline to npm Trusted Publishing (OIDC)

### DIFF
--- a/.changeset/oidc-trusted-publishing.md
+++ b/.changeset/oidc-trusted-publishing.md
@@ -1,0 +1,13 @@
+---
+'@gridsmith/core': patch
+'@gridsmith/react': patch
+---
+
+Switch the release pipeline to npm Trusted Publishing (OIDC) and enable provenance attestations.
+
+Each tarball now ships with a Sigstore-signed npm provenance attestation linking the
+release back to the GitHub Actions workflow that built it
+(`retemper/gridsmith` → `.github/workflows/publish.yml`). Consumers can verify the
+chain with `npm audit signatures`. No long-lived npm token is required for releases —
+the publish workflow authenticates to the registry via short-lived GitHub OIDC
+identities scoped to this repo and workflow path.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,15 +31,15 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Upgrade npm for Trusted Publishing
+        run: npm install -g npm@latest
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm turbo build
 
       - name: Publish to npm
         run: pnpm changeset:publish --no-git-tag
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create git tags and GitHub Releases
         run: |

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,10 @@
     "dist"
   ],
   "sideEffects": false,
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,6 +21,10 @@
     "dist"
   ],
   "sideEffects": false,
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",


### PR DESCRIPTION
## Summary

- Drop the `NPM_TOKEN`/`NODE_AUTH_TOKEN` env wiring from `.github/workflows/publish.yml` so the publish job authenticates to the npm registry via the workflow's short-lived GitHub OIDC identity (Trusted Publisher), removing the Granular Access Token that ENEEDAUTH/E404'd from CI during the 1.0.0 release.
- Add `publishConfig.access` and `publishConfig.provenance` to `@gridsmith/core` and `@gridsmith/react` so each tarball ships a Sigstore-signed npm provenance attestation tied back to this repo + workflow.
- Upgrade to `npm@latest` (>=11.5) before `pnpm changeset:publish`, since Node 22 ships npm 10.x which predates Trusted Publishing support.
- Patch changeset bumps `@gridsmith/core` and `@gridsmith/react` to 1.0.1 so the version PR is small and tests the new pipeline end-to-end.

## Pre-merge checklist (already done on the npm side)

- [x] `@gridsmith/core` → Settings → Trusted Publishers → GitHub Actions / `retemper/gridsmith` / `publish.yml`
- [x] `@gridsmith/react` → same configuration

## Post-merge cleanup (after a successful 1.0.1 publish)

- Revoke the `NPM_TOKEN` repo secret on `retemper/gridsmith`.
- Delete the `gridsmith-release` Granular token on npm.

## Test plan

- [ ] Merge this PR.
- [ ] Trigger the Version workflow (`workflow_dispatch`); verify it produces a `chore: version packages` PR bumping core+react to 1.0.1 with the OIDC changeset entry in CHANGELOG.
- [ ] Merge the version PR.
- [ ] Confirm the publish workflow run succeeds (no token, OIDC auth, npm 11.x).
- [ ] Confirm `npm view @gridsmith/core@1.0.1 --json` lists `attestations.provenance` and `dist.signatures` from the workflow.
- [ ] Confirm `npm audit signatures` against a fresh install passes.
- [ ] Confirm GitHub Releases for `@gridsmith/core@1.0.1` and `@gridsmith/react@1.0.1` are created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)