### PR TITLE
ci: install npm to a separate prefix for Trusted Publishing

### DIFF
--- a/.changeset/fix-npm-upgrade-step.md
+++ b/.changeset/fix-npm-upgrade-step.md
@@ -1,0 +1,13 @@
+---
+'@gridsmith/core': patch
+'@gridsmith/react': patch
+---
+
+Re-attempt the 1.0.x publish via npm Trusted Publishing.
+
+The 1.0.1 publish workflow failed at the "Install npm" step: `npm install -g npm@latest`
+crashed mid-upgrade with `Cannot find module 'promise-retry'`, a known
+self-replacement bug in npm 10.x. The publish job now installs the newer npm
+into a separate prefix (`$HOME/.npm-trusted`) and prepends it to `PATH`, which
+avoids touching the running npm's module tree. No package behavior changes; this
+release is the first to actually ship through OIDC + provenance attestation.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,8 +31,10 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Upgrade npm for Trusted Publishing
-        run: npm install -g npm@latest
+      - name: Install npm >=11.5 for Trusted Publishing
+        run: |
+          npm install -g npm@latest --prefix "$HOME/.npm-trusted"
+          echo "$HOME/.npm-trusted/bin" >> "$GITHUB_PATH"
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

The 1.0.1 publish workflow ([run](https://github.com/retemper/gridsmith/actions/runs/25115930800)) crashed at the npm upgrade step with:

\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - .../node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
\`\`\`

This is the [known npm 10.x → 11.x self-replacement bug](https://github.com/npm/cli/issues/7657) — the running npm 10.x tries to load `@npmcli/arborist` modules while those modules are being replaced by the new install, and fails.

Fix: install npm into a sibling prefix (`$HOME/.npm-trusted`) and prepend it to `PATH`. The running npm 10.x's own module tree is never touched, and later steps pick up the new npm via PATH.

A patch changeset is included so a 1.0.2 version PR can drive the end-to-end OIDC publish verification — 1.0.1 was bumped on main by PR #53 but never reached npm because of this failure.

## Test plan

- [ ] Merge this PR.
- [ ] Trigger the Version workflow (`gh workflow run version.yml`); confirm a `chore: version packages` PR opens bumping core+react 1.0.1 → 1.0.2.
- [ ] Merge the version PR.
- [ ] Confirm the publish workflow reaches the publish step and authenticates via OIDC (no NPM_TOKEN, npm 11.x in PATH).
- [ ] Confirm `npm view @gridsmith/core@1.0.2 --json` exposes provenance attestations.
- [ ] Confirm `@gridsmith/core@1.0.2` and `@gridsmith/react@1.0.2` GitHub Releases are created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)