### PR TITLE
ci: drop setup-node registry-url so OIDC trusted publishing engages

### DIFF
--- a/.changeset/fix-oidc-npmrc.md
+++ b/.changeset/fix-oidc-npmrc.md
@@ -1,0 +1,16 @@
+---
+'@gridsmith/core': patch
+'@gridsmith/react': patch
+---
+
+Re-attempt the 1.0.x publish via npm Trusted Publishing.
+
+The 1.0.2 publish workflow signed the Sigstore provenance attestation
+successfully but the registry PUT was rejected with `E404`. Root cause: the
+`actions/setup-node` step had `registry-url: 'https://registry.npmjs.org'`,
+which writes an `.npmrc` containing `_authToken=${NODE_AUTH_TOKEN}`. With no
+token in scope the line still resolves to "auth configured but empty", and
+npm CLI 11 falls through to that empty credential instead of switching to the
+OIDC trusted-publishing flow. Dropping `registry-url` from `setup-node`
+removes the stub `.npmrc`, so npm CLI sees no configured auth and exchanges
+the workflow's OIDC identity for a short-lived publish token as intended.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,6 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install npm >=11.5 for Trusted Publishing
         run: |


### PR DESCRIPTION
## Summary

The 1.0.2 publish workflow ([run](https://github.com/retemper/gridsmith/actions/runs/25141073218)) cleared all the previous blockers — npm 11.x was in PATH, OIDC was obtained, the Sigstore provenance attestation was signed and recorded — but the registry PUT was still rejected:

\`\`\`
publish Signed provenance statement with source and build information from GitHub Actions
publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=1406406235
error E404 PUT https://registry.npmjs.org/@gridsmith/core
\`\`\`

The root cause is \`actions/setup-node\`'s \`registry-url:\` input. It writes an \`.npmrc\` containing:

\`\`\`
//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}
\`\`\`

Even when \`NODE_AUTH_TOKEN\` is unset, the line still parses as "auth is configured" — just to an empty value. npm CLI 11 then commits to that empty credential instead of falling through to the OIDC trusted-publishing flow, so the actual upload request goes out unauthenticated and the registry replies 404.

Drop \`registry-url:\` from \`setup-node\`. Without it the stub \`.npmrc\` is never created, npm CLI sees no \`_authToken\` configured, and exchanges the workflow's OIDC identity for a short-lived publish token via the trusted publishers already registered for \`@gridsmith/core\` and \`@gridsmith/react\`. The default registry is already \`registry.npmjs.org\`, so dropping the explicit URL has no other effect.

A patch changeset is included so a 1.0.3 version PR can drive the verification end-to-end (1.0.1 and 1.0.2 are bumped on \`main\` but neither reached npm).

## Test plan

- [ ] Merge this PR.
- [ ] Trigger Version workflow; confirm a \`chore: version packages\` PR opens bumping core+react 1.0.2 → 1.0.3.
- [ ] Merge the version PR.
- [ ] Confirm the publish run succeeds end-to-end (no NPM_TOKEN, OIDC handshake, npm 11.x).
- [ ] Confirm \`npm view @gridsmith/core@1.0.3 --json | jq .dist.attestations\` is non-empty.
- [ ] Confirm GitHub Releases for \`@gridsmith/core@1.0.3\` and \`@gridsmith/react@1.0.3\` are created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)