### PR TITLE
ci: publish via direct npm publish to engage OIDC trusted publishing

### DIFF
--- a/.changeset/oidc-direct-npm-publish.md
+++ b/.changeset/oidc-direct-npm-publish.md
@@ -1,0 +1,16 @@
+---
+'@gridsmith/core': patch
+'@gridsmith/react': patch
+---
+
+Re-attempt the 1.0.x publish via npm Trusted Publishing.
+
+The 1.0.3 publish workflow surfaced that `pnpm changeset:publish` (and the
+underlying `pnpm publish`) does not implement npm's OIDC trusted-publishing
+handshake, so without an `_authToken` in `.npmrc` it fails fast with
+`ENEEDAUTH`. npm CLI 11.5+ does implement the handshake natively when
+invoked directly. Replace the publish step with a tarball-based loop:
+`pnpm pack` per package (so workspace `workspace:*` deps are rewritten to
+real versions), then `npm publish <tarball> --access public --provenance`,
+which triggers the OIDC token exchange against the trusted publishers
+already configured for `@gridsmith/core` and `@gridsmith/react`.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,8 +39,33 @@ jobs:
 
       - run: pnpm turbo build
 
-      - name: Publish to npm
-        run: pnpm changeset:publish --no-git-tag
+      - name: Publish unpublished packages via OIDC trusted publishing
+        run: |
+          set -e
+          npm --version
+          for pkg_json in $(find packages -name 'package.json' -not -path '*/node_modules/*'); do
+            pkg_dir=$(dirname "$pkg_json")
+            private=$(jq -r '.private // false' "$pkg_json")
+            if [ "$private" = "true" ]; then
+              echo "Skipping $(jq -r '.name' "$pkg_json") (private)"
+              continue
+            fi
+
+            name=$(jq -r '.name' "$pkg_json")
+            version=$(jq -r '.version' "$pkg_json")
+
+            if npm view "${name}@${version}" version > /dev/null 2>&1; then
+              echo "Skipping ${name}@${version} (already published)"
+              continue
+            fi
+
+            echo "::group::Pack and publish ${name}@${version}"
+            pack_dir=$(mktemp -d)
+            (cd "$pkg_dir" && pnpm pack --pack-destination "$pack_dir")
+            tarball=$(ls "$pack_dir"/*.tgz | head -1)
+            npm publish "$tarball" --access public --provenance
+            echo "::endgroup::"
+          done
 
       - name: Create git tags and GitHub Releases
         run: |


### PR DESCRIPTION
## Summary

The 1.0.3 publish workflow ([run](https://github.com/retemper/gridsmith/actions/runs/25173971505)) finally produced a clear signal: with the stub `.npmrc` from `setup-node` removed, `pnpm changeset:publish` failed with:

```
🦋 error ENEEDAUTH This command requires you to be logged in to https://registry.npmjs.org
🦋 error You need to authorize this machine using `npm adduser`
```

Root cause: pnpm's publish path — which `@changesets/cli` calls when pnpm is the package manager — does **not** implement npm's OIDC trusted-publishing handshake. It only loads existing credentials from `.npmrc` / env vars and errors out when none are configured. There is no fallback to id-token exchange.

npm CLI 11.5+ **does** implement the handshake natively, but only when invoked directly. Replace the publish step with a tarball-based loop:

- For each non-private workspace package whose declared version is not yet on npm: `pnpm pack` to build the tarball (workspace `*` ranges are rewritten to real versions in the packed manifest), then `npm publish <tarball> --access public --provenance` to upload via the trusted-publishing path.
- Already-published versions are detected with `npm view` and skipped — matches the behavior `pnpm changeset:publish` provided.
- The git tag / GitHub Release step still iterates the same set of package.jsons, drop-in replacement.

A patch changeset is included so a 1.0.4 version PR can drive the verification (1.0.1, 1.0.2, 1.0.3 are bumped on `main` but none reached npm).

## Test plan

- [ ] Merge this PR.
- [ ] Trigger Version workflow; confirm a `chore: version packages` PR opens bumping core+react 1.0.3 → 1.0.4.
- [ ] Merge the version PR.
- [ ] Confirm the publish run reaches `npm publish <tarball>` and authenticates via OIDC against the trusted publishers.
- [ ] Confirm `npm view @gridsmith/core@1.0.4 --json | jq .dist.attestations` is non-empty.
- [ ] Confirm `npm view @gridsmith/react@1.0.4 dependencies` shows `@gridsmith/core: ^1.0.4` (workspace ranges rewritten).
- [ ] Confirm GitHub Releases for `@gridsmith/core@1.0.4` and `@gridsmith/react@1.0.4` are created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)