### PR TITLE
ci: align snapshot.yml with the OIDC trusted-publishing flow

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -40,7 +40,11 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install npm >=11.5 for Trusted Publishing
+        run: |
+          npm install -g npm@latest --prefix "$HOME/.npm-trusted"
+          echo "$HOME/.npm-trusted/bin" >> "$GITHUB_PATH"
 
       - run: pnpm install --frozen-lockfile
 
@@ -51,10 +55,39 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish snapshot to npm
-        run: pnpm changeset:publish --tag "pr${{ github.event.issue.number }}" --no-git-tag
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish snapshot via OIDC trusted publishing
+        run: |
+          set -e
+          tag="pr${{ github.event.issue.number }}"
+          for pkg_json in $(find packages -name 'package.json' -not -path '*/node_modules/*'); do
+            pkg_dir=$(dirname "$pkg_json")
+            private=$(jq -r '.private // false' "$pkg_json")
+            if [ "$private" = "true" ]; then
+              echo "Skipping $(jq -r '.name' "$pkg_json") (private)"
+              continue
+            fi
+
+            name=$(jq -r '.name' "$pkg_json")
+            version=$(jq -r '.version' "$pkg_json")
+
+            # Snapshot versions look like 0.0.0-prN-<sha>; if changeset:version
+            # didn't bump this package (no changeset), keep skipping it so we
+            # don't republish a real release version under the snapshot tag.
+            case "$version" in
+              *"-${tag}-"*) ;;
+              *)
+                echo "Skipping ${name}@${version} (no snapshot for tag ${tag})"
+                continue
+                ;;
+            esac
+
+            echo "::group::Pack and publish ${name}@${version} (tag ${tag})"
+            pack_dir=$(mktemp -d)
+            (cd "$pkg_dir" && pnpm pack --pack-destination "$pack_dir")
+            tarball=$(ls "$pack_dir"/*.tgz | head -1)
+            npm publish "$tarball" --access public --provenance --tag "$tag"
+            echo "::endgroup::"
+          done
 
       - name: Comment install instructions on PR
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7


### PR DESCRIPTION
## Summary

`NPM_TOKEN` was deleted from repo secrets after publish.yml moved to npm OIDC trusted publishing, but `snapshot.yml` still references `secrets.NPM_TOKEN` and uses `pnpm changeset:publish`. pnpm's publish path doesn't implement npm's OIDC handshake (that's why publish.yml had to switch to `npm publish <tarball>` directly), so any `/snapshot` comment after the cleanup would have failed at the publish step.

Mirror publish.yml's working pattern in snapshot.yml:

- Drop `registry-url` from `setup-node`. No stub `.npmrc` is written, so npm CLI 11.5+ falls through to the OIDC code path instead of the empty-token short-circuit.
- Install npm `>=11.5` into a sibling prefix and prepend to PATH (Trusted Publishing requires it).
- Replace `pnpm changeset:publish` with a tarball loop: `pnpm pack` per package (workspace ranges are rewritten to the snapshot version in the packed manifest), then `npm publish <tarball> --access public --provenance --tag prN` so the upload runs through OIDC and the artifact lands under the PR dist-tag, never `latest`.
- The loop only publishes packages whose declared version actually carries the `-prN-` snapshot suffix. If `changeset:version --snapshot` had no changesets for a package, that package's version is unchanged, and we skip it instead of republishing the real release under the snapshot tag.

No changeset; this is a CI-only change.

## Test plan

- [ ] Merge this PR.
- [ ] On any open PR with a pending changeset, comment `/snapshot` and confirm the workflow run completes.
- [ ] Confirm `npm view @gridsmith/core@prN dist-tags` lists the PR-specific tag and the version is suffixed with `-prN-<sha>`.
- [ ] Confirm `latest` on `@gridsmith/core` is still `1.0.4` (snapshot did not move it).
- [ ] Confirm the install-instructions comment is posted to the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)